### PR TITLE
Issue #12238 Don't drop duplicate timestamps from separate deployments

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+NEXT RELEASE
+
+Issue #12238 - Don't drop duplicate timestamps from separate deployments
+
 Release 1.3.5
 
 Issue #12215 - Sampling strategy returns data outside query bounds

--- a/util/datamodel.py
+++ b/util/datamodel.py
@@ -104,13 +104,6 @@ def to_xray_dataset(cols, data, stream_key, request_uuid, san=False):
     dataset = xr.Dataset(attrs=attrs)
     dataframe = pd.DataFrame(data=data, columns=cols)
 
-    # # sometimes we will get duplicate timestamps
-    # # INITIAL solution is to remove any duplicate timestamps
-    # # and the corresponding data by creating a mask to match
-    # # only valid INCREASING times
-    mask = np.diff(np.insert(dataframe.time.values, 0, 0.0)) != 0
-    dataframe = dataframe[mask]
-
     for column in dataframe.columns:
         if column in app.config['INTERNAL_OUTPUT_EXCLUDE_LIST']:
             continue


### PR DESCRIPTION
Change-Id: I9d7f68722087d4b96af4501f7b8ee6751cdc510b