### PR TITLE
Issue #12501

### DIFF
--- a/manage-streamng
+++ b/manage-streamng
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# use the miniconda ooi/engine environment
-source activate engine
-
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 PIDFILE="$HERE/stream_engine.pid"


### PR DESCRIPTION
Removing "source activate engine" so users who need to run this script can utilize their own Conda environment that may be named something other than "engine".