### PR TITLE
Issue #12444 Prevent crash on open ended annotations - wrong ticket #

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,43 +1,49 @@
-Release 1.3.8
+# Stream Engine
+
+# In-Development 1.3.8 2017-09-XX
+
+Issue #11444 - Prevent crash on open ended annotations
 
 Issue #12318 - Filter NetCDF by selected parameters
 
-Release 1.3.7
-
 Issue #12072 - enforce order on XDeployment JSON fields for readability
+
+# Release 1.3.7 2017-07-20
+
 Issue #12238 - Don't drop duplicate timestamps from separate deployments
+
 Issue #12456 - Source in conda engine environment when running via script
 
-Release 1.3.6
+# Release 1.3.6
 
 Issue #9306 - Provide depth source for fixed ADCP instruments
 
-Release 1.3.5
+# Release 1.3.5
 
 Issue #12215 - Sampling strategy returns data outside query bounds
 
-Release 1.3.4
+# Release 1.3.4
 
 Update preload database to 1.0.12
 Update xarray from 0.8.2 to 0.9.2
 Handle unsigned int8 values in netcdf4 classic
 Encode asset management last modified timestamp as string
 
-Release 1.3.3
+# Release 1.3.3
 
 Update preload database to 1.0.11
 Update ion-functions to 2.3.1
 
-Release 1.3.2
+# Release 1.3.2
 
 Update preload database to 1.0.10
 
-Release 1.3.1
+# Release 1.3.1
 
 Fix issue with QC results and update numpy
 Update preload database to 1.0.9
 
-Release 1.3.0
+# Release 1.3.0
 
 Updated required packages
 - numpy
@@ -49,34 +55,34 @@ Updated required packages
 - xarray
 - pandas
 
-Release 1.2.10
+# Release 1.2.10
 
 Fix bugs preventing virtual stream computation
 OOI Data version 0.0.5
 Preload database version 1.0.8
 
-Release 1.2.9
+# Release 1.2.9
 
 Issue #12040 - parameter resolution error
 Issue #10396 - parameter resolution error
 Issue #4107 - dissolved oxygen computation fixes
 Issue #9011 - dissolved oxygen computation fixes
 
-Release 1.2.8
+# Release 1.2.8
 
 Issue #12035
 - Update resolution of L2 parameters that depend on other L2
 
-Release 1.2.7
+# Release 1.2.7
 
 Migrate preload data model to ooi_data
 
-Release 1.2.6
+# Release 1.2.6
 
 Issue #10777
 - Don't report all data masked when querying virtual streams
 
-Release 1.2.5
+# Release 1.2.5
 
 Issue #11871
 - Don't consider out-of-range bins when computing particle count estimate
@@ -84,7 +90,7 @@ Issue #11871
 Issue #11783 Add QC Flag to annotations
 - Updated AnnotationRecord to include QCFlag
 
-Release 1.2.4
+# Release 1.2.4
 
 Issue #11952
 - Updated aggregation response to be JSON (was plain string)
@@ -95,7 +101,7 @@ Issue #11861
 Issue #10777
 - modify stream_engine to utilize deployment times to bound product generation requests
 
-Release 1.2.3
+# Release 1.2.3
 
 Issue #11753
 - Aggregation fails when string lengths differ between datasets
@@ -103,7 +109,7 @@ Issue #11753
 Issue #11715
 - Added source attribute to the AnnotationRecord class to identify the creator of the data.
 
-Release 1.2.2
+# Release 1.2.2
 
 Issue #11646
 - Production generation fails if no asset management data exists for one or more deployments
@@ -111,17 +117,17 @@ Issue #11646
 Issue #11642
 - Bumped preload database pointer (v1.0.1) for "bin sizes incorrect in preload database"
 
-Release 1.2.1
+# Release 1.2.1
 
 Issue #11371
 - Updated NetCDF header sensor asset management information
 
-Release 1.2.0
+# Release 1.2.0
 
 Issue #11371
 - Add sensor asset management information to NetCDF header
 
-Release 1.1.2
+# Release 1.1.2
 
 Issue #11624
 - Aggregation fails for CSV files
@@ -132,7 +138,7 @@ Issue #11623
 Issue #11613
 - Fixed hard-coded log level in util/gather.py
 
-Release 1.1.1
+# Release 1.1.1
 
 Issue #11528
 - Accept the "execute_dpa" flag. When set to false no data product algorithms will be executed.
@@ -142,17 +148,17 @@ Issue #10820
 
 Updated preload database pointer
 
-Release 1.1.0
+# Release 1.1.0
 
 Issue #10820 - NetCDF aggregation
 - Stream engine will now aggregate the output from subjobs into one or more larger files
 
-Release 1.0.3
+# Release 1.0.3
 
 Issue #11497 - Incorrectly building 2D string arrays
 - Fixed an issue which caused some queries to abort when the requested stream contains string arrays
 
-Release 1.0.2
+# Release 1.0.2
 
 Issue #11499 - Simplify overriding configuration values in Stream Engine
 - Moved default configuration from config.py to config/default.py


### PR DESCRIPTION
- allow open ended annotations to be correctly deserialized, but
  prevent them from being used as other logic hasn't been updated
  to handle endDT values of None
- update RELEASE_NOTES file format in preparation for possibly
  hooking it into versions service
- fix incorrectly placed issue in RELEASE_NOTES