### PR TITLE
Issue #12072 - enforce order on provenance JSON - fixed ordering in a…

### DIFF
--- a/util/aggregation.py
+++ b/util/aggregation.py
@@ -12,7 +12,7 @@ import jinja2
 import numpy as np
 
 from engine import app
-from util.common import log_timing
+from util.common import log_timing, sort_dict, PROVENANCE_KEYORDER
 from util.datamodel import compile_datasets
 from util.gather import gather_files
 from util.netcdf_utils import write_netcdf, add_dynamic_attributes, analyze_datasets
@@ -141,6 +141,9 @@ def aggregate_provenance(job_dir, output_dir, request_id=None):
     for group in groups:
         aggregate_dict = aggregate_provenance_group(job_dir, groups[group])
         with open(os.path.join(output_dir, '%s_aggregate_provenance.json' % group), 'w') as fh:
+            # json.load undoes the ordering of provenance_metadata - reapply correct order here
+            for key in aggregate_dict['instrument_provenance']:
+                aggregate_dict['instrument_provenance'][key] = [sort_dict(e, PROVENANCE_KEYORDER, sorted_first=False) for e in aggregate_dict['instrument_provenance'][key]]
             json.dump(aggregate_dict, fh, indent=2)
 
 

--- a/util/common.py
+++ b/util/common.py
@@ -18,6 +18,13 @@ stream_cache = {}
 parameter_cache = {}
 function_cache = {}
 
+PROVENANCE_KEYORDER = ["eventId", "editPhase", "eventName", "eventType", "referenceDesignator", "deploymentNumber",
+                       "versionNumber", "inductiveId", "assetUid", "dataSource", "lastModifiedTimestamp", "tense", 
+                       "ingestInfo", "notes", "mooring", "mooring.location.location", "node", "node.location.location", 
+                       "eventStartTime", "eventStopTime", "waterDepth", "location", "location.location", "deployedBy", 
+                       "deployCruiseInfo", "recoveredBy", "recoverCruiseInfo", "sensor", "sensor.location.location", 
+                       "sensor.calibration"]
+
 
 def isfillvalue(a):
     """

--- a/util/provenance_metadata_store.py
+++ b/util/provenance_metadata_store.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import requests
 
 from util.calculated_provenance_metadata_store import CalculatedProvenanceMetadataStore
-from util.common import ntp_to_datestring, WriteErrorException, sort_dict
+from util.common import ntp_to_datestring, WriteErrorException, sort_dict, PROVENANCE_KEYORDER
 from util.jsonresponse import NumpyJSONEncoder
 
 log = logging.getLogger(__name__)
@@ -38,14 +38,8 @@ class ProvenanceMetadataStore(object):
     def add_instrument_provenance(self, stream_key, events):
         # reorder the JSON fields for readability
         # The JSON spec is unordered - this ordering should not be relied upon by code!
-        keyorder = ["eventId", "editPhase", "eventName", "eventType", "referenceDesignator", "deploymentNumber",
-                    "versionNumber", "inductiveId", "assetUid", "dataSource", "lastModifiedTimestamp", "tense", 
-                    "ingestInfo", "notes", "mooring", "mooring.location.location", "node", "node.location.location", 
-                    "eventStartTime", "eventStopTime", "waterDepth", "location", "location.location", "deployedBy", 
-                    "deployCruiseInfo", "recoveredBy", "recoverCruiseInfo", "sensor", "sensor.location.location", 
-                    "sensor.calibration"]
         # sorted_first = False so that sensor.calibration comes after the other sensor fields
-        events = [sort_dict(e, keyorder, sorted_first=False) for e in events]
+        events = [sort_dict(e, PROVENANCE_KEYORDER, sorted_first=False) for e in events]
         self._instrument_provenance[stream_key.as_three_part_refdes()] = events
 
     def get_instrument_provenance(self):


### PR DESCRIPTION
The initial 12072 commit failed to enforce order on the aggregate JSON provenance files (i.e. only worked for synchronous requests). This push fixes that oversight.