### PR TITLE
Issue #11828 - prevent time parameter from being filtered so aggregat…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 # Stream Engine
 
-# In-Development 1.3.9 2017-10-19
+# In-Development 1.3.9 2017-11-01
+
+Issue #12828 - Prevent time parameter from being filtered so aggregation works
 
 Issue #11543 - Add annotations to NetCDF and CSV requests
 

--- a/util/netcdf_generator.py
+++ b/util/netcdf_generator.py
@@ -55,7 +55,8 @@ class NetcdfGenerator(object):
     def _filter_params(self, ds, params):
         missing_params = []
         params_to_filter = []
-        default_params = ['deployment', 'id', 'lat', 'lon', 'quality_flag']
+        # aggregation logic assumes the presence of a 'time' parameter, so do not allow it to get removed
+        default_params = ['time', 'deployment', 'id', 'lat', 'lon', 'quality_flag']
 
         for param in params:
             if param not in ds.data_vars:


### PR DESCRIPTION
This change addresses 3 separate issues: 1) The bug noted in ticket 12828 wherein a mismatch between dataset attribute name and stream parameter name results in the dataset.time attribute getting erroneously dropped. This no longer happens since 'time' can no longer be dropped. 2) If filtering parameters are specified for a stream request, and if 'time' (pid 7) was excluded, aggregation would fail like in ticket 12828. Again, the inability to exclude 'time' fixes this. 3) Aggregation failures caused by items 1 and 2 would lead to the status.txt file not getting written. Fixing those issues should therefore fix the subject of ticket 12004 (status.txt not getting written) as well.