### PR TITLE
Issue #12515 Use preload data from postgres

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Stream Engine
 
-# In-Development 1.3.9 2017-11-07
+# In-Development 1.3.10 2017-11-16
+
+Issue #12515 - Use preload data from postgres
+
+# Release 1.3.9 2017-11-07
 
 Issue #12544 - Add derived and external parameter attributes
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -204,6 +204,6 @@ def post_fork(server, worker):
         worker.log.debug('Connecting worker to cassandra')
         _init()
         worker.log.debug('Connected worker to cassandra')
-        engine = create_engine_from_url(None)
+        engine = create_engine_from_url(r'postgresql://awips:awips@localhost/metadata')
         Session = create_scoped_session(engine)
         MetadataBase.query = Session.query_property()

--- a/run.py
+++ b/run.py
@@ -7,7 +7,7 @@ from util.cass import _init
 from ooi_data.postgres.model import MetadataBase
 from preload_database.database import create_engine_from_url
 
-engine = create_engine_from_url(None)
+engine = create_engine_from_url(r'postgresql://awips:awips@localhost/metadata')
 Session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 MetadataBase.query = Session.query_property()
 


### PR DESCRIPTION
Has been tested on uframe-3-test allowing plotting of a zplsc echogram through loading of preload from postgres.