### PR TITLE
Issue #12916 Enable starting stream_engine from any folder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 # In-Development 1.3.10 2017-11-16
 
+Issue #12916 - Enable starting stream_engine from any folder
+
 Issue #12515 - Use preload data from postgres
 
 # Release 1.3.9 2017-11-07

--- a/manage-streamng
+++ b/manage-streamng
@@ -17,7 +17,7 @@ start(){
 
     if [ ! -f $PIDFILE ]; then
         export OOI_GUNICORN_LOG_LOC=$HERE
-        gunicorn --pythonpath $HERE --log-config $HERE/logging.conf --daemon -p $PIDFILE --config $HERE/gunicorn_config.py engine.routes:app
+        gunicorn --chdir $HERE --pythonpath $HERE --log-config $HERE/logging.conf --daemon -p $PIDFILE --config $HERE/gunicorn_config.py engine.routes:app
     else
         echo "$NAME: Trying to start stream engine, but pid exists"
     fi


### PR DESCRIPTION
Tested this on uframe-3-test yesterday by starting stream_engine running "manage_streamng start" from the miniconda2 folder within the anaconda environment. I ran a request provided from Seth that triggered an aggregation. I verified within the logs that no exception occurred and that a file named status.txt containing "complete" was generated within a new folder inside /opt/ooi/async/seth on that server.