### PR TITLE
Issue #12879 Exclude data without a deployment

### DIFF
--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -194,7 +194,10 @@ class StreamDataset(object):
                     deployment_event = self.events.deps[deployment]
                     mask = (dataset.time.values >= deployment_event.ntp_start) & \
                            (dataset.time.values < deployment_event.ntp_stop)
-                    masks[deployment] = mask
+                else:
+                    mask = np.zeros_like(dataset.time.values).astype('bool')
+                masks[deployment] = mask
+
             self._mask_datasets(masks)
 
     def _build_function_arguments(self, dataset, stream_key, funcmap, deployment, source_dataset=None):


### PR DESCRIPTION
This fix will filter out any data that does not have a corresponding deployment in asset management.