### PR TITLE
Issue #12715 - standardize status file naming

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 # Stream Engine
 
-# Development Release 1.3.11 2017-12-19
+# Development Release 1.3.11 2018-01-04
+
+Issue #12715 - Standardize status file naming
 
 Issue #12004 - Add aggregation exception handling
 

--- a/engine/routes.py
+++ b/engine/routes.py
@@ -248,7 +248,6 @@ def netcdf_save_to_filesystem():
         json_str = output_async_error(input_data, e, filename=json_efile)
 
     status_filename = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "status.txt")
-
     write_status(base_path, filename=status_filename)
     return Response(json_str, mimetype='application/json')
 
@@ -293,8 +292,8 @@ def particles_save_to_filesystem():
                   % (message + ". " if code == 500 else "", base_path)
         code = 500
 
-    write_status(base_path)
-
+    status_filename = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "status.txt")
+    write_status(base_path, filename=status_filename)
     return Response(json.dumps({'code': code, 'message': message}, indent=2), mimetype='application/json')
 
 
@@ -326,12 +325,15 @@ def _delimited_fs(delimiter):
     """
     input_data = request.get_json()
     base_path = get_local_dir(input_data)
+
     try:
         json_str = util.calc.get_csv_fs(input_data, request.url, base_path, delimiter=delimiter)
     except Exception as e:
-        json_str = output_async_error(input_data, e)
+        json_efile = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "failure.json")
+        json_str = output_async_error(input_data, e, filename=json_efile)
 
-    write_status(base_path)
+    status_filename = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "status.txt")
+    write_status(base_path, filename=status_filename)
     return Response(json_str, mimetype='application/json')
 
 


### PR DESCRIPTION
NetCDF status and failure file naming conventions used start and end times in their filenames, but CSV and JSON requests did not use the same convention. Status aggregation logic assumes the start and end time naming convention and therefore did not work correctly for CSV and JSON requests. I modified the logic so that CSV and JSON requests use the start and end time naming pattern and verified this fixed status file aggregation in both cases.

The initial problem observed in ticket 12715 was caused by output directory collisions as addressed by changes for ticket 11983.