### PR TITLE
Revert "Issue #12879 Exclude data without a deployment"

### DIFF
--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -196,10 +196,7 @@ class StreamDataset(object):
                     deployment_event = self.events.deps[deployment]
                     mask = (dataset.time.values >= deployment_event.ntp_start) & \
                            (dataset.time.values < deployment_event.ntp_stop)
-                else:
-                    mask = np.zeros_like(dataset.time.values).astype('bool')
-                masks[deployment] = mask
-
+                    masks[deployment] = mask
             self._mask_datasets(masks)
 
     def _build_function_arguments(self, dataset, stream_key, funcmap, deployment, source_dataset=None):


### PR DESCRIPTION
Reverts oceanobservatories/stream_engine#35

Issue #13105 identified several streams which no longer could be downloaded and traced the problem back to this fix which needs to be revisited. In the meantime we are reverting this change so that data can be viewed/downloaded.