### PR TITLE
Issue #13195 Fix empty data error for custom dims

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,10 @@ Issue #9328 - Make interpolated ctd pressure available
 - add interpolated ctd pressure to the data request
 - ensure interpolated ctd pressure is included in NetCDF and CSV
 
+# Release 1.4.1 2018-02-13
+
+Issue #13195 - Fix empty datasets with custom dims not being handled correctly
+
 # Release 1.4.00 2018-02-02
 
 Issue #12001 - Do not open provenance/annotation files in append mode

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -400,7 +400,7 @@ class StreamDataset(object):
             # remove obs dimension from parameter's dimensions and data (13025 AC2)
             param_dimensions.remove('-obs')
             dims = param_dimensions
-            data = data[0]
+            data = data[0] if data else None
         elif param_dimensions:
             # append parameter dimensions onto obs
             dims += param_dimensions


### PR DESCRIPTION
As ticket states, caught this while working issue #12879.

Bug will currently only affect optaa since that's the only thing that has a custom dimension currently defined and also will only affect attempting to request unbounded data (which I'm not sure if this is possible for optaa, this is a special cause I ran into while forcing the data into a state where a deployment wasn't defined for it, to test work for #12879).

