### PR TITLE
Issue #12879 Exclude data without a deployment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 # Stream Engine
 
-# Development Release 1.4.1 2018-02-09
+# Development Release 1.5.0 2018-02-12
+
+Issue #12879 - Prevent data without deployment info from returning
+- add require_deployment query parameter and default configuration setting
+
+By default, data without deployments will not be returned via data requests.
+The default behavior is configured via the REQUIRE_DEPLOYMENT variable in default.py
+
+To override the default behavior on a per request basis, set the query parameter
+require_deployment=false when making a data request.
 
 Issue #9328 - Make interpolated ctd pressure available
 - add interpolated ctd pressure to the data request

--- a/config/default.py
+++ b/config/default.py
@@ -213,6 +213,11 @@ AGGREGATION_TIMEOUT_SECONDS = 7200
 ############################
 # Query Settings           #
 ############################
+# If require_deployment isn't specified during a data request, this sets the default behavior (12879)
+# True: data must have a deployment event defined to be returned
+# False: data without deployment events are allowed to return
+REQUIRE_DEPLOYMENT = True
+
 COLLAPSE_TIMES = True
 # If the ratio of total data to requested points is less than this value all of the data is returned
 UI_FULL_RETURN_RATIO = 2.0

--- a/util/calc.py
+++ b/util/calc.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 RequestParameters = namedtuple('RequestParameters', ['id', 'streams', 'coefficients', 'uflags', 'start', 'stop',
                                                      'limit', 'include_provenance', 'include_annotations',
                                                      'qc_parameters', 'strict_range', 'location_information',
-                                                     'execute_dpa'])
+                                                     'execute_dpa', 'require_deployment'])
 
 
 def execute_stream_request(request_parameters, needs_only=False):
@@ -48,7 +48,8 @@ def execute_stream_request(request_parameters, needs_only=False):
             strict_range=request_parameters.strict_range,
             request_id=request_parameters.id,
             collapse_times=collapse_times,
-            execute_dpa=request_parameters.execute_dpa))
+            execute_dpa=request_parameters.execute_dpa,
+            require_deployment=request_parameters.require_deployment))
 
         if not needs_only:
             stream_request[index].fetch_raw_data()
@@ -146,9 +147,10 @@ def validate(input_data):
     strict = input_data.get('strict_range', False)
     locs = input_data.get('locations', {})
     execute_dpa = input_data.get('execute_dpa', True)
+    require_deployment = input_data.get('require_deployment', app.config["REQUIRE_DEPLOYMENT"])
 
     return RequestParameters(request_id, streams, coefficients, user_flags, start,
-                             stop, limit, prov, annotate, qc, strict, locs, execute_dpa)
+                             stop, limit, prov, annotate, qc, strict, locs, execute_dpa, require_deployment)
 
 
 def _validate_coefficients(input_data):

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -400,7 +400,7 @@ class StreamDataset(object):
             # remove obs dimension from parameter's dimensions and data (13025 AC2)
             param_dimensions.remove('-obs')
             dims = param_dimensions
-            data = data[0] if data else None
+            data = data[0]
         elif param_dimensions:
             # append parameter dimensions onto obs
             dims += param_dimensions

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -187,16 +187,25 @@ class StreamDataset(object):
 
             self._mask_datasets(masks)
 
-    def exclude_nondeployed_data(self):
+    def exclude_nondeployed_data(self, require_deployment=True):
+        """
+        Exclude data outside of deployment times.
+        :param require_deployment: True to exclude all data without deployment information,
+                                   False to include data without deployment info.
+        :return: Nothing, this function directly modifies the underlying dataset.
+        """
         masks = {}
         if self.events is not None:
             for deployment in self.datasets:
                 dataset = self.datasets[deployment]
                 if deployment in self.events.deps:
+                    # if a deployment exists use it to restrict the range of values
                     deployment_event = self.events.deps[deployment]
-                    mask = (dataset.time.values >= deployment_event.ntp_start) & \
+                    masks[deployment] = (dataset.time.values >= deployment_event.ntp_start) & \
                            (dataset.time.values < deployment_event.ntp_stop)
-                    masks[deployment] = mask
+                elif require_deployment:
+                    # if a deployment doesn't exist and we require_deployment, restrict all values
+                    masks[deployment] = np.zeros_like(dataset.time.values).astype('bool')
             self._mask_datasets(masks)
 
     def _build_function_arguments(self, dataset, stream_key, funcmap, deployment, source_dataset=None):
@@ -391,7 +400,7 @@ class StreamDataset(object):
             # remove obs dimension from parameter's dimensions and data (13025 AC2)
             param_dimensions.remove('-obs')
             dims = param_dimensions
-            data = data[0]
+            data = data[0] if data else None
         elif param_dimensions:
             # append parameter dimensions onto obs
             dims += param_dimensions

--- a/util/stream_request.py
+++ b/util/stream_request.py
@@ -37,7 +37,7 @@ class StreamRequest(object):
 
     def __init__(self, stream_key, parameters, time_range, uflags, qc_parameters=None,
                  limit=None, include_provenance=False, include_annotations=False, strict_range=False,
-                 request_id='', collapse_times=False, execute_dpa=True):
+                 request_id='', collapse_times=False, execute_dpa=True, require_deployment=True):
 
         if not isinstance(stream_key, StreamKey):
             raise StreamEngineException('Received no stream key', status_code=400)
@@ -54,6 +54,7 @@ class StreamRequest(object):
         self.include_annotations = include_annotations
         self.strict_range = strict_range
         self.execute_dpa = execute_dpa
+        self.require_deployment = require_deployment
 
         # Internals
         self.asset_management = AssetManagement(ASSET_HOST, request_id=self.request_id)
@@ -233,7 +234,7 @@ class StreamRequest(object):
         :return:
         """
         for stream_key, stream_dataset in self.datasets.iteritems():
-            stream_dataset.exclude_nondeployed_data()
+            stream_dataset.exclude_nondeployed_data(self.require_deployment)
 
     def import_extra_externals(self):
         # import any other required "externals" into all datasets


### PR DESCRIPTION
For data without deployments, prevent the data from being returned, but allow this default behavior to be overridden on a per request basis or changed globally via the configuration file.

I have corresponding EDEX changes in the uframe-ooi repo that goes with these changes.  I'll get that code in for review tomorrow.