### PR TITLE
Issue #13126 - Include data gap and open ended annotations in annotat…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 # Development Release 1.5.0 2018-02-12
 
+Issue #13126 - Include open ended and data gap annotations
+- async requests write annotation files even if no particle data is found
+- annotation data is aggregated to a single annotation.json file
+- open ended annotation are included in annotation.json file
+- async JSON responses return particle and annotation data
+
 Issue #12879 - Prevent data without deployment info from returning
 - add require_deployment query parameter and default configuration setting
 

--- a/engine/routes.py
+++ b/engine/routes.py
@@ -242,7 +242,7 @@ def netcdf_save_to_filesystem():
     base_path = get_local_dir(input_data)
 
     try:
-        _, json_str = util.calc.get_netcdf(input_data, request.url)
+        _, json_str = util.calc.get_netcdf(input_data, request.url, base_path)
     except Exception as e:
         json_efile = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "failure.json")
         json_str = output_async_error(input_data, e, filename=json_efile)
@@ -261,40 +261,16 @@ def particles_save_to_filesystem():
     """
     input_data = request.get_json()
     base_path = get_local_dir(input_data)
-    filename = '{:s}.json'.format(StreamKey.from_dict(input_data.get('streams')[0]).as_dashed_refdes())
-    file_path = os.path.join(base_path, filename)
-
-    code = 200
-    message = str([file_path])
 
     try:
-        json_output = util.calc.get_particles(input_data, request.url)
-    except (MissingDataException, MissingTimeException) as e:
-        # treat as empty
-        log.warning(e)
-        # set contents of stream.json to empty
-        json_output = json.dumps({})
+        json_str = util.calc.get_particles_fs(input_data, request.url, base_path)
     except Exception as e:
-        # set code to error
-        code = 500
-        # make message be the error code
-        message = "Request for particles failed for the following reason: " + e.message
-        # set the contents of failure.json
-        json_output = json.dumps({'code': 500, 'message': message, 'requestUUID': input_data.get('requestUUID', '')})
-        filename = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "failure.json")
-        file_path = os.path.join(base_path, filename)
-        log.exception(json_output)
-
-    # try to write file, if it does not succeed then return an error
-    if not write_file_with_content(base_path, file_path, json_output):
-        # if the code is 500, append message, otherwise replace it with this error
-        message = "%sSupplied directory '%s' is invalid. Path specified exists but is not a directory." \
-                  % (message + ". " if code == 500 else "", base_path)
-        code = 500
+        json_efile = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "failure.json")
+        json_str = output_async_error(input_data, e, filename=json_efile)
 
     status_filename = time_prefix_filename(input_data.get('start'), input_data.get('stop'), "status.txt")
     write_status(base_path, filename=status_filename)
-    return Response(json.dumps({'code': code, 'message': message}, indent=2), mimetype='application/json')
+    return Response(json_str, mimetype='application/json')
 
 
 @app.route('/csv-fs', methods=['POST'])

--- a/test/test_annotations.py
+++ b/test/test_annotations.py
@@ -26,6 +26,7 @@ class AnnotationTest(unittest.TestCase):
     def setUp(self):
         self.amhost = 'localhost'
         self.refdes = 'CE04OSPS-SF01B-2A-CTDPFA107'
+        self.sk = StreamKey('CP01CNSM', 'MFD37', '04-DOSTAD000', 'telemetered', 'dosta_abcdjm_dcl_instrument')
 
     def test_create_interface(self):
         return AnnotationServiceInterface(self.amhost)
@@ -38,49 +39,51 @@ class AnnotationTest(unittest.TestCase):
         for anno in anno_interface.find_annotations(key, time_range):
             print anno._tuple
 
-    def _create_exclusion_anno(self, start, stop):
-        return AnnotationRecord(beginDT=start, endDT=stop, exclusionFlag=True)
+    def _create_exclusion_anno(self, streamkey, start, stop):
+        key = streamkey.as_dict()
+        return AnnotationRecord(beginDT=start, endDT=stop, subsite=key['subsite'], node=key['node'],
+            sensor=key['sensor'], method=key['method'], stream=key['stream'], exclusionFlag=True)
 
-    def _test_single_exclusion(self, tstart, tstop, astart, astop, expected):
-        return self._test_multiple_exclusions(tstart, tstop, [(astart, astop)], expected)
+    def _test_single_exclusion(self, streamkey, tstart, tstop, astart, astop, expected):
+        return self._test_multiple_exclusions(streamkey, tstart, tstop, [(astart, astop)], expected)
 
-    def _test_multiple_exclusions(self, tstart, tstop, annos, expected):
+    def _test_multiple_exclusions(self, streamkey, tstart, tstop, annos, expected):
         # all times in whole seconds since 1970
         # adapt to expected formats
         times = np.arange(ntplib.system_to_ntp_time(tstart), ntplib.system_to_ntp_time(tstop + 1))
         store = AnnotationStore()
-        store.add_annotations([self._create_exclusion_anno(start*1000, stop*1000) for start, stop in annos])
-        mask = store.get_exclusion_mask(times)
+        store.add_annotations([self._create_exclusion_anno(streamkey, start*1000, stop*1000) for start, stop in annos])
+        mask = store.get_exclusion_mask(streamkey, times)
         self.assertEqual(list(mask), expected)
 
     def test_exclude_all(self):
-        self._test_single_exclusion(1, 5, 1, 5, [False, False, False, False, False])
+        self._test_single_exclusion(self.sk, 1, 5, 1, 5, [False, False, False, False, False])
 
     def test_exclude_single(self):
-        self._test_single_exclusion(1, 5, 1, 4, [False, False, False, False, True])
-        self._test_single_exclusion(1, 5, 2, 5, [True, False, False, False, False])
-        self._test_single_exclusion(1, 5, 2, 4, [True, False, False, False, True])
+        self._test_single_exclusion(self.sk, 1, 5, 1, 4, [False, False, False, False, True])
+        self._test_single_exclusion(self.sk, 1, 5, 2, 5, [True, False, False, False, False])
+        self._test_single_exclusion(self.sk, 1, 5, 2, 4, [True, False, False, False, True])
 
     def test_exclude_multiple_non_overlapping(self):
-        self._test_multiple_exclusions(1, 10, [(1, 2), (9, 10)],
+        self._test_multiple_exclusions(self.sk, 1, 10, [(1, 2), (9, 10)],
                                        [False, False, True, True, True, True, True, True, False, False])
-        self._test_multiple_exclusions(1, 10, [(3, 4), (6, 8)],
+        self._test_multiple_exclusions(self.sk, 1, 10, [(3, 4), (6, 8)],
                                        [True, True, False, False, True, False, False, False, True, True])
-        self._test_multiple_exclusions(1, 10, [(1, 2), (3, 4)],
+        self._test_multiple_exclusions(self.sk, 1, 10, [(1, 2), (3, 4)],
                                        [False, False, False, False, True, True, True, True, True, True])
 
     def test_exclude_multiple_overlapping(self):
-        self._test_multiple_exclusions(1, 10, [(1, 4), (3, 5)],
+        self._test_multiple_exclusions(self.sk, 1, 10, [(1, 4), (3, 5)],
                                        [False, False, False, False, False, True, True, True, True, True])
-        self._test_multiple_exclusions(1, 10, [(1, 4), (2, 3)],
+        self._test_multiple_exclusions(self.sk, 1, 10, [(1, 4), (2, 3)],
                                        [False, False, False, False, True, True, True, True, True, True])
 
     def test_non_matching(self):
-        self._test_single_exclusion(1, 5, 7, 10, [True] * 5)
+        self._test_single_exclusion(self.sk, 1, 5, 7, 10, [True] * 5)
 
     def test_bigger(self):
-        self._test_single_exclusion(5, 10, 1, 20, [False] * 6)
+        self._test_single_exclusion(self.sk, 5, 10, 1, 20, [False] * 6)
 
     def test_bigger_one_side(self):
-        self._test_single_exclusion(5, 10, 1, 8, [False, False, False, False, True, True])
-        self._test_single_exclusion(5, 10, 7, 20, [True, True, False, False, False, False])
+        self._test_single_exclusion(self.sk, 5, 10, 1, 8, [False, False, False, False, True, True])
+        self._test_single_exclusion(self.sk, 5, 10, 7, 20, [True, True, False, False, False, False])

--- a/test/test_stream_dataset.py
+++ b/test/test_stream_dataset.py
@@ -16,7 +16,7 @@ from ion_functions.data.ctd_functions import ctd_sbe16plus_tempwat, ctd_pracsal
 from preload_database.database import create_engine_from_url, create_scoped_session
 from ooi_data.postgres.model import Parameter, MetadataBase
 from util.advlogging import jdefault
-from util.annotation import AnnotationRecord
+from util.annotation import AnnotationRecord, AnnotationStore
 from util.asset_management import AssetEvents
 from util.common import StreamKey
 from util.stream_dataset import StreamDataset
@@ -67,8 +67,10 @@ class StreamDatasetTest(unittest.TestCase):
                 if not filled and expect_fill:
                     self.assertFalse(True, msg='parameter (%s) not filled (as expected)' % parameter)
 
-    def _create_exclusion_anno(self, start, stop):
-        return AnnotationRecord(beginDT=start, endDT=stop, exclusionFlag=True)
+    def _create_exclusion_anno(self, streamkey, start, stop):
+        key = streamkey.as_dict()
+        return AnnotationRecord(beginDT=start, endDT=stop, subsite=key['subsite'], node=key['node'],
+                                sensor=key['sensor'], method=key['method'], stream=key['stream'], exclusionFlag=True)
 
     def test_calculate_internal_single_deployment(self):
         ctd_ds = xr.open_dataset(os.path.join(DATA_DIR, self.ctdpf_fn), decode_times=False)
@@ -281,30 +283,31 @@ class StreamDatasetTest(unittest.TestCase):
                          'pressure_temp', 'conductivity', 'ext_volt0']]
 
         times = ctd_ds.time.values
+        store = AnnotationStore()
 
         ctd_stream_dataset = StreamDataset(self.ctdpf_sk, {}, [], 'UNIT')
         ctd_stream_dataset.events = self.ctd_events
         ctd_stream_dataset._insert_dataset(ctd_ds)
-
-        ctd_stream_dataset.exclude_flagged_data()
+        
+        ctd_stream_dataset.exclude_flagged_data(store)
         np.testing.assert_array_equal(times, ctd_stream_dataset.datasets[2].time.values)
 
         # exclude a bit
         start = ntplib.ntp_to_system_time(times[0]) * 1000
         stop = ntplib.ntp_to_system_time(times[100]) * 1000
-        anno = self._create_exclusion_anno(start, stop)
-        ctd_stream_dataset.annotation_store.add_annotations([anno])
+        anno = self._create_exclusion_anno(self.ctdpf_sk, start, stop)
+        store.add_annotations([anno])
 
-        ctd_stream_dataset.exclude_flagged_data()
+        ctd_stream_dataset.exclude_flagged_data(store)
         np.testing.assert_array_equal(times[101:], ctd_stream_dataset.datasets[2].time.values)
 
         # exclude everything
         start = ntplib.ntp_to_system_time(times[0]) * 1000
         stop = ntplib.ntp_to_system_time(times[-1]) * 1000
-        anno = self._create_exclusion_anno(start, stop)
-        ctd_stream_dataset.annotation_store.add_annotations([anno])
+        anno = self._create_exclusion_anno(self.ctdpf_sk, start, stop)
+        store.add_annotations([anno])
 
-        ctd_stream_dataset.exclude_flagged_data()
+        ctd_stream_dataset.exclude_flagged_data(store)
         self.assertNotIn(2, ctd_stream_dataset.datasets)
 
     def test_insert_valid_scalar_data(self):

--- a/test/test_stream_request.py
+++ b/test/test_stream_request.py
@@ -447,23 +447,24 @@ class StreamRequestTest(unittest.TestCase):
 
         with mock.patch('util.stream_request.StreamRequest.fetch_raw_data', new=mock_fetch_raw_data):
             with mock.patch('util.stream_request.StreamRequest._collapse_times'):
-                sr = execute_stream_request(validate(input_data), True)
-                self.assertEqual(len(sr.external_includes), 1)
+                with mock.patch('util.stream_request.StreamRequest.insert_annotations'):
+                    sr = execute_stream_request(validate(input_data), True)
+                    self.assertEqual(len(sr.external_includes), 1)
 
-                sr = execute_stream_request(validate(input_data))
-                # stream engine should only return requested parameters
-                self.assertEqual(len(sr.external_includes), len(input_data['streams']))
-                self.assertIn(self.echo_sk, sr.external_includes)
-                expected = {Parameter.query.get(2575)}
-                self.assertEqual(expected, sr.external_includes[self.echo_sk])
+                    sr = execute_stream_request(validate(input_data))
+                    # stream engine should only return requested parameters
+                    self.assertEqual(len(sr.external_includes), len(input_data['streams']))
+                    self.assertIn(self.echo_sk, sr.external_includes)
+                    expected = {Parameter.query.get(2575)}
+                    self.assertEqual(expected, sr.external_includes[self.echo_sk])
 
-                self.assertIn(self.nut_sk, sr.external_includes)
-                expected = Parameter.query.get(2327)
-                self.assertIn(expected, sr.external_includes[self.nut_sk])
-                expected = Parameter.query.get(2328)
-                self.assertIn(expected, sr.external_includes[self.nut_sk])
-                expected = Parameter.query.get(2329)
-                self.assertIn(expected, sr.external_includes[self.nut_sk])
+                    self.assertIn(self.nut_sk, sr.external_includes)
+                    expected = Parameter.query.get(2327)
+                    self.assertIn(expected, sr.external_includes[self.nut_sk])
+                    expected = Parameter.query.get(2328)
+                    self.assertIn(expected, sr.external_includes[self.nut_sk])
+                    expected = Parameter.query.get(2329)
+                    self.assertIn(expected, sr.external_includes[self.nut_sk])
 
     def test_execute_stream_request_multiple_streams_invalid_input(self):
         input_data = json.load(open(os.path.join(DATA_DIR, 'multiple_stream_request_no_parameter.json')))

--- a/util/aggregation.py
+++ b/util/aggregation.py
@@ -87,9 +87,7 @@ def output_ncml(mapping, request_id=None):
         }
 
         with codecs.open(combined_file, 'wb', 'utf-8') as ncml_file:
-            ncml_file.write(
-                    ncml_template.render(coord_dict=info_dict, attr_dict=attr_dict,
-                                         var_dict=variable_dict))
+            ncml_file.write(ncml_template.render(coord_dict=info_dict, attr_dict=attr_dict, var_dict=variable_dict))
 
 
 def generate_combination_map(out_dir, subjob_info):
@@ -150,8 +148,9 @@ def aggregate_provenance(job_dir, output_dir, request_id=None):
 
 @log_timing(log)
 def aggregate_annotations(job_dir, output_dir, request_id=None):
-    anno_label = 'annotations_'
-    aggregate_dict = {'annotations': []}
+    anno_string = 'annotations'
+    anno_label = anno_string + '_'
+    aggregate_dict = {anno_string: []}
     recorded_annotation_ids = []
     anno_file_count = 0
     for f in os.listdir(job_dir):
@@ -160,7 +159,7 @@ def aggregate_annotations(job_dir, output_dir, request_id=None):
             path = os.path.join(job_dir, f)
             data = json.load(open(path))
             for key in data:
-                if key == 'annotations':
+                if key == anno_string:
                     new_annotations = [x for x in data[key] if x['id'] not in recorded_annotation_ids]
                     recorded_annotation_ids.extend([v['id'] for v in new_annotations])
                     aggregate_dict[key].extend(new_annotations)
@@ -169,7 +168,7 @@ def aggregate_annotations(job_dir, output_dir, request_id=None):
     
     # only write aggregate file if we encountered sub-job annotation files
     if anno_file_count > 0:
-        with open(os.path.join(output_dir, 'annotations.json'), 'w') as fh:
+        with open(os.path.join(output_dir, anno_string + '.json'), 'w') as fh:
             json.dump(aggregate_dict, fh, indent=2)
 
 

--- a/util/aggregation.py
+++ b/util/aggregation.py
@@ -345,7 +345,8 @@ def aggregate_status(job_dir, out_dir, request_id=None):
 
 @log_timing(log)
 def aggregate_csv(job_dir, out_dir, request_id=None):
-    # TODO -- aggregate CSV/TSV files
+    # TODO -- aggregate CSV/TSV files - current logic copies files over
+    # as is instead of combining them when applicable
     for f in fnmatch.filter(os.listdir(job_dir), '*.[ct]sv'):
         shutil.move(os.path.join(job_dir, f),
                     os.path.join(out_dir, f))
@@ -353,7 +354,8 @@ def aggregate_csv(job_dir, out_dir, request_id=None):
 
 @log_timing(log)
 def aggregate_json(job_dir, out_dir, request_id=None):
-    # TODO -- aggregate JSON files
+    # TODO -- aggregate JSON files - current logic copies files over
+    # as is instead of combining them when applicable
     for f in fnmatch.filter(os.listdir(job_dir), '*.json'):
         # only process particle data files
         if 'deployment' in f and not ('annotation' in f or 'provenance' in f):

--- a/util/aggregation.py
+++ b/util/aggregation.py
@@ -148,34 +148,28 @@ def aggregate_provenance(job_dir, output_dir, request_id=None):
             json.dump(aggregate_dict, fh, indent=2)
 
 
-def aggregate_annotation_group(job_dir, files):
-    aggregate_dict = {'annotations': []}
-    recorded_annotation_ids = []
-    for f in sorted(files):
-        path = os.path.join(job_dir, f)
-        data = json.load(open(path))
-        for key in data:
-            if key == 'annotations':
-                new_annotations = [x for x in data[key] if x['id'] not in recorded_annotation_ids]
-                recorded_annotation_ids.extend([v['id'] for v in new_annotations])
-                aggregate_dict[key].extend(new_annotations)
-            else:
-                aggregate_dict.setdefault(key, {})[f] = data[key]
-    return aggregate_dict
-
-
 @log_timing(log)
 def aggregate_annotations(job_dir, output_dir, request_id=None):
-    groups = {}
-    anno_label = '_annotations_'
+    anno_label = 'annotations_'
+    aggregate_dict = {'annotations': []}
+    recorded_annotation_ids = []
+    anno_file_count = 0
     for f in os.listdir(job_dir):
         if anno_label in f and f.endswith('json'):
-            group = f.split(anno_label)[0]
-            groups.setdefault(group, []).append(f)
-            
-    for group in groups:
-        aggregate_dict = aggregate_annotation_group(job_dir, groups[group])
-        with open(os.path.join(output_dir, '%s_aggregate_annotations.json' % group), 'w') as fh:
+            anno_file_count += 1
+            path = os.path.join(job_dir, f)
+            data = json.load(open(path))
+            for key in data:
+                if key == 'annotations':
+                    new_annotations = [x for x in data[key] if x['id'] not in recorded_annotation_ids]
+                    recorded_annotation_ids.extend([v['id'] for v in new_annotations])
+                    aggregate_dict[key].extend(new_annotations)
+                else:
+                    aggregate_dict.setdefault(key, {})[f] = data[key]
+    
+    # only write aggregate file if we encountered sub-job annotation files
+    if anno_file_count > 0:
+        with open(os.path.join(output_dir, 'annotations.json'), 'w') as fh:
             json.dump(aggregate_dict, fh, indent=2)
 
 
@@ -359,6 +353,16 @@ def aggregate_csv(job_dir, out_dir, request_id=None):
 
 
 @log_timing(log)
+def aggregate_json(job_dir, out_dir, request_id=None):
+    # TODO -- aggregate JSON files
+    for f in fnmatch.filter(os.listdir(job_dir), '*.json'):
+        # only process particle data files
+        if 'deployment' in f and not ('annotation' in f or 'provenance' in f):
+            shutil.move(os.path.join(job_dir, f),
+                        os.path.join(out_dir, f))
+
+
+@log_timing(log)
 def cleanup(job_dir, request_id=None):
     """
     All files have been aggregated, remove the pre-aggregation files
@@ -422,6 +426,7 @@ def aggregate(async_job_dir, request_id=None):
 
     try:
         aggregate_status(local_dir, final_dir, request_id=request_id)
+        aggregate_json(local_dir, final_dir, request_id=request_id)
         aggregate_csv(local_dir, final_dir, request_id=request_id)
         aggregate_netcdf(local_dir, final_dir, request_id=request_id)
         aggregate_provenance(local_dir, final_dir, request_id=request_id)

--- a/util/calc.py
+++ b/util/calc.py
@@ -205,7 +205,7 @@ def _validate_stream(stream, empty_param_check=False):
 
     if empty_param_check and len(parameters) == 0:
         raise InvalidParameterException('The parameter list for the secondary stream is empty',
-                                            payload={'stream': stream})
+                                        payload={'stream': stream})
 
     stream_parameters = [p.id for p in preload_stream.parameters]
     for pid in parameters:
@@ -233,7 +233,7 @@ def _write_annotations(stream_request, base_path):
     
     if stream_request.include_annotations:
         time_range_string = str(stream_request.time_range).replace(" ", "")
-        anno_fname = 'annotations_%s.json' % (time_range_string)
+        anno_fname = 'annotations_%s.json' % time_range_string
         anno_json = os.path.join(base_path, anno_fname)
         stream_request.annotation_store.dump_json(anno_json)
 

--- a/util/common.py
+++ b/util/common.py
@@ -86,6 +86,13 @@ def ntp_to_datestring(ntp_time):
     return dt.isoformat()
 
 
+def ntp_to_short_iso_datestring(ntp_time):
+    dt = ntp_to_datetime(ntp_time)
+    if dt is None:
+        return str(ntp_time)
+    return dt.strftime("%Y%m%dT%H%M%S")
+
+
 class TimeRange(object):
     def __init__(self, start, stop):
         self.start = start

--- a/util/csvresponse.py
+++ b/util/csvresponse.py
@@ -6,7 +6,7 @@ import tempfile
 import zipfile
 
 from engine import app
-from util.common import ntp_to_datestring, WriteErrorException
+from util.common import ntp_to_short_iso_datestring, WriteErrorException
 
 log = logging.getLogger(__name__)
 
@@ -62,13 +62,22 @@ class CsvGenerator(object):
         
     def _create_files(self, base_path):
         file_paths = []
+        
+        # annotation data will be written to a JSON file
+        if self.stream_request.include_annotations:
+            time_range_string = str(self.stream_request.time_range).replace(" ", "")
+            anno_fname = 'annotations_%s.json' % (time_range_string)
+            anno_json = os.path.join(base_path, anno_fname)
+            file_paths.append(anno_json)
+            self.stream_request.annotation_store.dump_json(anno_json)
+        
         stream_key = self.stream_request.stream_key
         stream_dataset = self.stream_request.datasets[stream_key]
         for deployment, ds in stream_dataset.datasets.iteritems():
             refdes = stream_key.as_dashed_refdes()
             times = ds.time.values
-            start = ntp_to_datestring(times[0])
-            end = ntp_to_datestring(times[-1])
+            start = ntp_to_short_iso_datestring(times[0])
+            end = ntp_to_short_iso_datestring(times[-1])
             
             # provenance types will be written to JSON files
             if self.stream_request.include_provenance:
@@ -77,14 +86,6 @@ class CsvGenerator(object):
                 prov_json = os.path.join(base_path, prov_fname)
                 file_paths.append(prov_json)
                 stream_dataset.provenance_metadata.dump_json(prov_json)
-            
-            # annotation data will be written to JSON files
-            if self.stream_request.include_annotations:
-                anno_fname = 'deployment%04d_%s_annotations_%s-%s.json' % (deployment,
-                                                                           stream_key.as_dashed_refdes(), start, end)
-                anno_json = os.path.join(base_path, anno_fname)
-                file_paths.append(anno_json)
-                stream_dataset.annotation_store.dump_json(anno_json)
 
             filename = 'deployment%04d_%s_%s-%s%s' % (deployment, refdes, start, end, self._get_suffix())
             file_path = os.path.join(base_path, filename)

--- a/util/csvresponse.py
+++ b/util/csvresponse.py
@@ -66,7 +66,7 @@ class CsvGenerator(object):
         # annotation data will be written to a JSON file
         if self.stream_request.include_annotations:
             time_range_string = str(self.stream_request.time_range).replace(" ", "")
-            anno_fname = 'annotations_%s.json' % (time_range_string)
+            anno_fname = 'annotations_%s.json' % time_range_string
             anno_json = os.path.join(base_path, anno_fname)
             file_paths.append(anno_json)
             self.stream_request.annotation_store.dump_json(anno_json)
@@ -74,7 +74,6 @@ class CsvGenerator(object):
         stream_key = self.stream_request.stream_key
         stream_dataset = self.stream_request.datasets[stream_key]
         for deployment, ds in stream_dataset.datasets.iteritems():
-            refdes = stream_key.as_dashed_refdes()
             times = ds.time.values
             start = ntp_to_short_iso_datestring(times[0])
             end = ntp_to_short_iso_datestring(times[-1])
@@ -87,7 +86,8 @@ class CsvGenerator(object):
                 file_paths.append(prov_json)
                 stream_dataset.provenance_metadata.dump_json(prov_json)
 
-            filename = 'deployment%04d_%s_%s-%s%s' % (deployment, refdes, start, end, self._get_suffix())
+            filename = 'deployment%04d_%s_%s-%s%s' % (deployment, stream_key.as_dashed_refdes(), start, end,
+                                                      self._get_suffix())
             file_path = os.path.join(base_path, filename)
 
             with open(file_path, 'w') as filehandle:

--- a/util/jsonresponse.py
+++ b/util/jsonresponse.py
@@ -69,7 +69,7 @@ class JsonResponse(object):
         # annotation data will be written to a JSON file
         if self.stream_request.include_annotations:
             time_range_string = str(self.stream_request.time_range).replace(" ", "")
-            anno_fname = 'annotations_%s.json' % (time_range_string)
+            anno_fname = 'annotations_%s.json' % time_range_string
             anno_json = os.path.join(base_path, anno_fname)
             file_paths.append(anno_json)
             self.stream_request.annotation_store.dump_json(anno_json)
@@ -79,7 +79,6 @@ class JsonResponse(object):
         parameters = self.stream_request.requested_parameters
         external_includes = self.stream_request.external_includes
         for deployment, ds in stream_dataset.datasets.iteritems():
-            refdes = stream_key.as_dashed_refdes()
             times = ds.time.values
             start = ntp_to_short_iso_datestring(times[0])
             end = ntp_to_short_iso_datestring(times[-1])
@@ -92,7 +91,7 @@ class JsonResponse(object):
                 file_paths.append(prov_json)
                 stream_dataset.provenance_metadata.dump_json(prov_json)
 
-            filename = 'deployment%04d_%s_%s-%s.json' % (deployment, refdes, start, end)
+            filename = 'deployment%04d_%s_%s-%s.json' % (deployment, stream_key.as_dashed_refdes(), start, end)
             file_path = os.path.join(base_path, filename)
             
             with open(file_path, 'w') as filehandle:
@@ -118,12 +117,9 @@ class JsonResponse(object):
         if stream_key.is_mobile:
             pressure_params = [(sk, param) for sk in external_includes for param in external_includes[sk]
                                if param.data_product_identifier == PRESSURE_DPI]
+            # only need to append pressure name (9328)
             if pressure_params:
-                pressure_key, pressure_param = pressure_params.pop()
-                pressure_name = '-'.join((pressure_key.stream.name, pressure_param.name))
-                if pressure_name in data:
-                    data[INT_PRESSURE_NAME] = data.pop(pressure_name)
-                    params.append(INT_PRESSURE_NAME)
+                params.append(INT_PRESSURE_NAME)
 
         # check if we should include and have positional data
         if stream_key.is_glider:

--- a/util/jsonresponse.py
+++ b/util/jsonresponse.py
@@ -1,3 +1,4 @@
+import os
 import json
 import logging
 from collections import OrderedDict
@@ -5,7 +6,7 @@ from datetime import datetime
 
 import numpy as np
 
-from common import log_timing
+from util.common import log_timing, ntp_to_short_iso_datestring, WriteErrorException
 from engine import app
 from ooi_data.postgres.model import Parameter, Stream
 
@@ -39,7 +40,7 @@ class JsonResponse(object):
         if self.stream_request.include_provenance:
             prov = self._provenance(stream_dataset.provenance_metadata)
         if self.stream_request.include_annotations:
-            anno = self._annotations(stream_dataset.annotation_store)
+            anno = self._annotations(self.stream_request.annotation_store)
 
         if prov or anno:
             out = OrderedDict()
@@ -54,6 +55,134 @@ class JsonResponse(object):
         return json.dumps(out, indent=2, cls=NumpyJSONEncoder)
 
     @log_timing(log)
+    def write_json(self, path):
+        file_paths = []
+        base_path = os.path.join(app.config['LOCAL_ASYNC_DIR'], path)
+
+        if not os.path.isdir(base_path):
+            try:
+                os.makedirs(base_path)
+            except OSError:
+                if not os.path.isdir(base_path):
+                    raise WriteErrorException('Unable to create local output directory: %s' % path)
+
+        # annotation data will be written to a JSON file
+        if self.stream_request.include_annotations:
+            time_range_string = str(self.stream_request.time_range).replace(" ", "")
+            anno_fname = 'annotations_%s.json' % (time_range_string)
+            anno_json = os.path.join(base_path, anno_fname)
+            file_paths.append(anno_json)
+            self.stream_request.annotation_store.dump_json(anno_json)
+
+        stream_key = self.stream_request.stream_key
+        stream_dataset = self.stream_request.datasets[stream_key]
+        parameters = self.stream_request.requested_parameters
+        external_includes = self.stream_request.external_includes
+        for deployment, ds in stream_dataset.datasets.iteritems():
+            refdes = stream_key.as_dashed_refdes()
+            times = ds.time.values
+            start = ntp_to_short_iso_datestring(times[0])
+            end = ntp_to_short_iso_datestring(times[-1])
+
+            # provenance types will be written to JSON files
+            if self.stream_request.include_provenance:
+                prov_fname = 'deployment%04d_%s_provenance_%s-%s.json' % (deployment,
+                                                                          stream_key.as_dashed_refdes(), start, end)
+                prov_json = os.path.join(base_path, prov_fname)
+                file_paths.append(prov_json)
+                stream_dataset.provenance_metadata.dump_json(prov_json)
+
+            filename = 'deployment%04d_%s_%s-%s.json' % (deployment, refdes, start, end)
+            file_path = os.path.join(base_path, filename)
+            
+            with open(file_path, 'w') as filehandle:
+                data = self._deployment_particles(ds, stream_key, parameters, external_includes)
+                json.dump(data, filehandle, indent=2, separators=(',', ': '), cls=NumpyJSONEncoder)
+            file_paths.append(file_path)
+
+        return json.dumps({"code": 200, "message": str(file_paths)}, indent=2)
+
+    @log_timing(log)
+    def _deployment_particles(self, ds, stream_key, parameters, external_includes):
+        particles = []
+        
+        # extract the underlying numpy arrays from the dataset (indexing into the dataset is expensive)
+        data = {}
+        for p in ds.data_vars:
+            data[p] = ds[p].values
+
+        # Extract the parameter names from the parameter objects
+        params = [p.name for p in parameters]
+
+        # check if we should include and have pressure data
+        if stream_key.is_mobile:
+            pressure_params = [(sk, param) for sk in external_includes for param in external_includes[sk]
+                               if param.data_product_identifier == PRESSURE_DPI]
+            if pressure_params:
+                pressure_key, pressure_param = pressure_params.pop()
+                pressure_name = '-'.join((pressure_key.stream.name, pressure_param.name))
+                if pressure_name in data:
+                    data[INT_PRESSURE_NAME] = data.pop(pressure_name)
+                    params.append(INT_PRESSURE_NAME)
+
+        # check if we should include and have positional data
+        if stream_key.is_glider:
+            lat_data = data.pop('glider_gps_position-m_gps_lat', None)
+            lon_data = data.pop('glider_gps_position-m_gps_lon', None)
+            if lat_data is not None and lon_data is not None:
+                data['lat'] = lat_data
+                data['lon'] = lon_data
+                params.extend(('lat', 'lon'))
+
+        # remaining externals
+        for sk in external_includes:
+            for param in external_includes[sk]:
+                name = '-'.join((sk.stream_name, param.name))
+                if name in data:
+                    params.append(name)
+
+        if self.stream_request.include_provenance:
+            params.append('provenance')
+
+        # add any QC if it exists
+        for param in params:
+            qc_postfixes = ['qc_results', 'qc_executed']
+            for qc_postfix in qc_postfixes:
+                qc_key = '%s_%s' % (param, qc_postfix)
+                if qc_key in data:
+                    params.append(qc_key)
+
+        # don't look for dimensional coordinate variables in data (13025 AC2)
+        for dim in ds.coords:
+            if dim in params:
+                params.remove(dim)
+
+        # Warn for any missing parameters
+        missing = [p for p in params if p not in data]
+        if missing:
+            log.warn('<%s> Failed to get data for %r: Not in Dataset', self.request_id, missing)
+
+        params = [p for p in params if p in data]
+
+        for index in xrange(len(ds.time)):
+            # Create our particle from the list of parameters
+            particle = {}
+            for p in params:
+                if p in ds and 'obs' not in ds[p].dims:
+                    # data has no obs dimension (13025 AC2)
+                    particle[p] = data[p]
+                else:
+                    # data is bound by obs dimension
+                    particle[p] = data[p][index]
+            particle['pk'] = stream_key.as_dict()
+            particle['pk']['time'] = data['time'][index]
+            if 'deployment' in data:
+                particle['pk']['deployment'] = data['deployment'][index]
+            particles.append(particle)
+            
+        return particles
+
+    @log_timing(log)
     def _particles(self, stream_data, stream_key, parameters, external_includes):
         """
         Convert an xray Dataset into a list of dictionaries, each representing a single point in time
@@ -62,76 +191,8 @@ class JsonResponse(object):
 
         for deployment in sorted(stream_data.datasets):
             ds = stream_data.datasets[deployment]
-            # extract the underlying numpy arrays from the dataset (indexing into the dataset is expensive)
-            data = {}
-            for p in ds.data_vars:
-                data[p] = ds[p].values
-
-            # Extract the parameter names from the parameter objects
-            params = [p.name for p in parameters]
-
-            # check if we should include and have pressure data
-            if stream_key.is_mobile:
-                pressure_params = [(sk, param) for sk in external_includes for param in external_includes[sk]
-                                   if param.data_product_identifier == PRESSURE_DPI]
-                # only need to append pressure name (9328)
-                if pressure_params:
-                    params.append(INT_PRESSURE_NAME)
-
-            # check if we should include and have positional data
-            if stream_key.is_glider:
-                lat_data = data.pop('glider_gps_position-m_gps_lat', None)
-                lon_data = data.pop('glider_gps_position-m_gps_lon', None)
-                if lat_data is not None and lon_data is not None:
-                    data['lat'] = lat_data
-                    data['lon'] = lon_data
-                    params.extend(('lat', 'lon'))
-
-            # remaining externals
-            for sk in external_includes:
-                for param in external_includes[sk]:
-                    name = '-'.join((sk.stream_name, param.name))
-                    if name in data:
-                        params.append(name)
-
-            if self.stream_request.include_provenance:
-                params.append('provenance')
-
-            # add any QC if it exists
-            for param in params:
-                qc_postfixes = ['qc_results', 'qc_executed']
-                for qc_postfix in qc_postfixes:
-                    qc_key = '%s_%s' % (param, qc_postfix)
-                    if qc_key in data:
-                        params.append(qc_key)
-
-            # don't look for dimensional coordinate variables in data (13025 AC2)
-            for dim in ds.coords:
-                if dim in params:
-                    params.remove(dim)
-
-            # Warn for any missing parameters
-            missing = [p for p in params if p not in data]
-            if missing:
-                log.warn('<%s> Failed to get data for %r: Not in Dataset', self.request_id, missing)
-
-            params = [p for p in params if p in data]
-
-            for index in xrange(len(ds.time)):
-                # Create our particle from the list of parameters
-                particle = {}
-                for p in params:
-                    if p in ds and 'obs' not in ds[p].dims:
-                        # data has no obs dimension (13025 AC2)
-                        particle[p] = data[p]
-                    else:
-                        # data is bound by obs dimension
-                        particle[p] = data[p][index]
-                particle['pk'] = stream_key.as_dict()
-                particle['pk']['time'] = data['time'][index]
-                if 'deployment' in data:
-                    particle['pk']['deployment'] = data['deployment'][index]
-                particles.append(particle)
+            deployment_particles = self._deployment_particles(ds, stream_key, parameters, external_includes)
+            particles.extend(deployment_particles)
         return particles
 
     @staticmethod

--- a/util/netcdf_generator.py
+++ b/util/netcdf_generator.py
@@ -106,7 +106,7 @@ class NetcdfGenerator(object):
             # coordinate variable shouldn't have coordinate attribute (10745 AC3)
             # only scientific variables should have coordinate attribute (10745 AC2)
             if var not in coordinate_variables \
-                    and var not in app.config.get('NETCDF_NONSCI_VARIABLES',[]):
+                    and var not in app.config.get('NETCDF_NONSCI_VARIABLES', []):
                 ds[var].attrs[coordinates_key] = coordinate_variables
             elif coordinates_key in ds[var].attrs:
                 del ds[var].attrs[coordinates_key]
@@ -126,7 +126,7 @@ class NetcdfGenerator(object):
         # annotation data will be written to a JSON file
         if self.stream_request.include_annotations:
             time_range_string = str(self.stream_request.time_range).replace(" ", "")
-            anno_fname = 'annotations_%s.json' % (time_range_string)
+            anno_fname = 'annotations_%s.json' % time_range_string
             anno_json = os.path.join(base_path, anno_fname)
             file_paths.append(anno_json)
             self.stream_request.annotation_store.dump_json(anno_json)
@@ -166,7 +166,7 @@ class NetcdfGenerator(object):
                         long_parameter_name = external_stream_key.stream_name+"-"+parameter.name
                         if long_parameter_name in ds:
                             # rename the parameter without the stream_name prefix (12544 AC1)
-                            ds = ds.rename({long_parameter_name : parameter.name})
+                            ds = ds.rename({long_parameter_name: parameter.name})
                             # record the instrument and stream (12544 AC2)
                             ds[parameter.name].attrs['instrument'] = external_stream_key.as_three_part_refdes()
                             ds[parameter.name].attrs['stream'] = external_stream_key.stream_name

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from ooi_data.postgres.model import Parameter, Stream
 from util.advlogging import ParameterReport
-from util.annotation import AnnotationStore
 from util.cass import fetch_nth_data, get_full_cass_dataset, get_cass_lookback_dataset
 from util.common import (log_timing, ntp_to_datestring, ntp_to_datetime, UnknownFunctionTypeException,
                          StreamEngineException, TimeRange, MissingDataException)
@@ -34,7 +33,6 @@ class StreamDataset(object):
     def __init__(self, stream_key, uflags, external_streams, request_id):
         self.stream_key = stream_key
         self.provenance_metadata = ProvenanceMetadataStore(request_id)
-        self.annotation_store = AnnotationStore()
         self.uflags = uflags
         self.external_streams = external_streams
         self.request_id = request_id
@@ -177,12 +175,12 @@ class StreamDataset(object):
                          self.request_id, self.stream_key, deployment)
                 del self.datasets[deployment]
 
-    def exclude_flagged_data(self):
+    def exclude_flagged_data(self, annotation_store):
         masks = {}
-        if self.annotation_store.has_exclusion():
+        if annotation_store.has_exclusion():
             for deployment in self.datasets:
                 dataset = self.datasets[deployment]
-                mask = self.annotation_store.get_exclusion_mask(dataset.time.values)
+                mask = annotation_store.get_exclusion_mask(self.stream_key, dataset.time.values)
                 masks[deployment] = mask
 
             self._mask_datasets(masks)

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -200,7 +200,7 @@ class StreamDataset(object):
                     # if a deployment exists use it to restrict the range of values
                     deployment_event = self.events.deps[deployment]
                     masks[deployment] = (dataset.time.values >= deployment_event.ntp_start) & \
-                           (dataset.time.values < deployment_event.ntp_stop)
+                        (dataset.time.values < deployment_event.ntp_stop)
                 elif require_deployment:
                     # if a deployment doesn't exist and we require_deployment, restrict all values
                     masks[deployment] = np.zeros_like(dataset.time.values).astype('bool')
@@ -244,8 +244,8 @@ class StreamDataset(object):
                     if cal is not None:
                         kwargs[name] = cal
                         if np.any(np.isnan(cal)):
-                            msg = '<{:s}> There was not coefficient data for {:s} for all times in deployment ' \
-                                  '{:d} in range ({:s} {:s})'.format(self.request_id, name, deployment, begin_dt, end_dt)
+                            msg = '<{:s}> There was not coefficient data for {:s} for all times in deployment {:d} ' \
+                                  'in range ({:s} {:s})'.format(self.request_id, name, deployment, begin_dt, end_dt)
                             log.warn(msg)
 
             # Internal Parameter
@@ -643,7 +643,7 @@ class StreamDataset(object):
                 version = 'Python ' + PYTHON_VERSION
                 # evaluate the function in an empty global namespace
                 # using the provided func.args as the local namespace
-                result = np.array(eval(func.function,{},kwargs))
+                result = np.array(eval(func.function, {}, kwargs))
 
             elif func.function_type == 'NumexprFunction':
                 version = 'unversioned'

--- a/util/stream_request.py
+++ b/util/stream_request.py
@@ -330,7 +330,7 @@ class StreamRequest(object):
         if self.stream_key.is_mobile:
             dpi = PRESSURE_DPI
             external_to_process.add((None, tuple(Parameter.query.filter(
-                    Parameter.data_product_identifier == dpi).all())))
+                Parameter.data_product_identifier == dpi).all())))
 
         if self.stream_key.is_glider:
             gps_stream = Stream.query.get(GPS_STREAM_ID)

--- a/util/stream_request.py
+++ b/util/stream_request.py
@@ -4,6 +4,7 @@ import math
 import util.annotation
 import util.metadata_service
 import util.provenance_metadata_store
+from util.annotation import AnnotationStore
 from engine import app
 from ooi_data.postgres.model import Parameter, Stream, NominalDepth
 from util.asset_management import AssetManagement
@@ -62,6 +63,7 @@ class StreamRequest(object):
         self.unfulfilled = set()
         self.datasets = {}
         self.external_includes = {}
+        self.annotation_store = AnnotationStore()
 
         self._initialize()
 
@@ -130,8 +132,6 @@ class StreamRequest(object):
                 sd.events = am_events[stream_key]
                 self.datasets[stream_key] = sd
 
-        # Fetch annotations
-        self._insert_annotations()
         self._exclude_flagged_data()
         self._exclude_nondeployed_data()
 
@@ -211,13 +211,12 @@ class StreamRequest(object):
                             prov = fetch_l0_provenance(stream_key, provenance, deployment)
                             prov_metadata.update_provenance(prov)
 
-    def _insert_annotations(self):
+    def insert_annotations(self):
         """
-        Insert all annotations for this request. This is dependent on the data already having been fetched.
-        :return:
+        Insert all annotations for this request.
         """
-        for stream_key, stream_dataset in self.datasets.iteritems():
-            stream_dataset.annotation_store.query_annotations(stream_key, self.time_range)
+        for stream_key in self.stream_parameters:
+            self.annotation_store.add_query_annotations(stream_key, self.time_range)
 
     def _exclude_flagged_data(self):
         """
@@ -226,7 +225,7 @@ class StreamRequest(object):
         :return:
         """
         for stream_key, stream_dataset in self.datasets.iteritems():
-            stream_dataset.exclude_flagged_data()
+            stream_dataset.exclude_flagged_data(self.annotation_store)
 
     def _exclude_nondeployed_data(self):
         """


### PR DESCRIPTION
Several fixes here: 1) Include open ended annotations in annotation.json file when a stream request has include_annotations=true. They were previously left out if lacking an end time. 2) Cause annotation data to be written to file in async requests even if there is no particle data for the request. This involved associating annotation_store with stream_request instead of stream_dataset and some MissingDataException handling. 3) Make annotation aggregation handle changes for 1 and 2, and write a single annotation.json file. 4) Rework the async JSON response so that it behaves along the same lines as CSV and NetCDF responses (writes annotation and provenance data to separate JSON files). Previously there was no aggregation logic for JSON, causing the files to never reach the async output directory.