### PR TITLE
Issue #13276 - wait for child process

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Stream Engine
 
-# Development Release 1.6.0 2018-06-26
+# Development Release 1.6.0 2018-07-18
 
 Issue #13448 - Prevent getting fill values for wavelength coordinate
 - Correct code error that led to NaNs for wavelength values
@@ -13,8 +13,6 @@ Issue #13063 - Parse the stream engine version from the release notes
 - Read the version from the release notes at runtime, use this for output to netcdf
   also display version in log when starting up
 
-Issue #13276 - Fix gunicorn compatibility issue with previous change
-
 Issue #13311 - Apply annotation masks in case of open-ended annotations
 
 Issue #13276 - Run qc in separate processes and detect empty directory aggregation
@@ -22,6 +20,9 @@ Issue #13276 - Run qc in separate processes and detect empty directory aggregati
   process dies without writting results to pipe
 - Add checks in aggregation so that status.json file records attempts to aggregate
   a directory with no files in it or a directory with no status files
+- Fix gunicorn compatibility issue with the above changes by using os.fork instead
+  of the python multiprocessing module
+- Make parent process wait for child to prevent zombie processes
 
 # Release 1.5.0 2018-04-16
 

--- a/util/qc_executor.py
+++ b/util/qc_executor.py
@@ -20,6 +20,7 @@ EXCEPTION_MESSAGE = "Logged Exception"
 QC_EXECUTED = 'qc_executed'
 QC_RESULTS = 'qc_results'
 
+
 class QcExecutor(object):
     """
     Class to manage the execution of all necessary QC for a request
@@ -101,33 +102,36 @@ class QcExecutor(object):
             processid = os.fork()
             if processid == 0:
                 # child process
-                with os.fdopen(w, 'w') as w:
-                    try:
-                        os.close(r)
-                        # run the qc function
-                        results = getattr(module, function_name)(**local_qc_args.get(function_name))
-                        # convert the np.ndarray into a string for sending over pipe
-                        bytes = io.BytesIO()
-                        np.savez(bytes, x=results)
-                        results_string = bytes.getvalue()
-                        w.write(results_string)
-                    except (TypeError, ValueError) as e:
-                        log.exception('<%s> Failed to execute QC %s %r', self.request_id, function_name, e)
-                        w.write(EXCEPTION_MESSAGE)
-                    finally:
-                        # if w.flush() is not called (or w.close()), the parent will not get data for results_string 
-                        w.flush()
-                        # child process is done, don't let it stick around
-                        os._exit(0)
+                # don't use 'with os.fdopen' since we call os._exit(0) below
+                w = os.fdopen(w, 'w')
+                try:
+                    os.close(r)
+                    # run the qc function
+                    results = getattr(module, function_name)(**local_qc_args.get(function_name))
+                    # convert the np.ndarray into a string for sending over pipe
+                    bytes = io.BytesIO()
+                    np.savez(bytes, x=results)
+                    results_string = bytes.getvalue()
+                    w.write(results_string)
+                except (TypeError, ValueError) as e:
+                    log.exception('<%s> Failed to execute QC %s %r', self.request_id, function_name, e)
+                    w.write(EXCEPTION_MESSAGE)
+                finally: 
+                    w.close()
+                    # child process is done, don't let it stick around
+                    os._exit(0)
             else:
                 # parent process
                 os.close(w)
                 with os.fdopen(r) as r:
                     results_string = r.read()
+                # wait for the child process to prevent zombies - second argument of 0 means default behavior of waitpid
+                os.waitpid(processid, 0)
                 # check for failure to produce results
                 if not results_string:
                     # an error, e.g. segfault, prevented proper qc execution, proceed with trying the next qc function
-                    log.error('<%s> Failed to execute QC %s: QC process failed to return any data', self.request_id, function_name)
+                    log.error('<%s> Failed to execute QC %s: QC process failed to return any data', self.request_id,
+                              function_name)
                     continue
                 elif results_string == EXCEPTION_MESSAGE:
                     # an exception has already been logged, proceed with trying the next qc function


### PR DESCRIPTION
I did not update the release notes here as they already contain an entry for ticket 13276 and this is just a fix to that fix (which is not yet released to production). I think this solves the zombie issue we've been seeing. I did some local testing before and after the change and verified zombies occurred when I made a data request without the fix and do not occur when I make a request after the fix.