### PR TITLE
Issue #13501 - remove unmatched coordinates during aggregation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,17 @@
 # Stream Engine
 
-# Development Release 1.7.0 2018-07-26
+# Development Release 1.8.0 2018-12-10
+
+Issue #13501 - Handle mismatched coordinates in NetCDF aggregation
+
+# Release 1.7.0 2018-07-26
 Issue #13101 - Replace simple aggregation timeout with inactivity timeout
 - Remove AGGREGATION_TIMEOUT_SECONDS config value
 - Add DEFAULT_MAX_RUNTIME, DEFAULT_ACTIVITY_POLL_PERIOD, AGGREGATION_MAX_RUNTIME, and 
   AGGREGATION_ACTIVITY_POLL_PERIOD config values
 - Create set_inactivity_timeout decorator and apply to aggregation function
 
-# Development Release 1.6.0 2018-07-20
+# Release 1.6.0 2018-07-20
 
 Issue #13448 - Prevent getting fill values for wavelength coordinate
 - Correct code error that led to NaNs for wavelength values

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Stream Engine
 
-# Development Release 1.8.0 2018-12-10
+# Development Release 1.8.0 2018-12-12
 
 Issue #13501 - Handle mismatched coordinates in NetCDF aggregation
 

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -51,6 +51,61 @@ class AggregationTest(unittest.TestCase):
             self.assertTrue((np.diff(ds.obs.values) > 0).all())
             self.assertTrue((np.diff(ds.time.values) > 0).all())
 
+    def test_aggregate_netcdf_handles_mismatched_coordinates(self):
+        f1 = os.path.join(self.tempdir, 'f1.nc')
+        f2 = os.path.join(self.tempdir, 'f2.nc')
+        ds = xr.Dataset()
+        ds['time'] = (['obs'], [1, 2, 4], {})
+        ds['x'] = (['obs'], [1, 2, 3], {})
+        ds.coords['obs'] = ('obs', [1, 2, 3])
+        ds.coords['lat'] = ('obs', [1, 2, 3])
+        ds.coords['lon'] = ('obs', [1, 2, 3])
+        ds.to_netcdf(f1)
+        ds['time'] = (['obs'], [3, 5, 6], {})
+        ds.coords['depth'] = ('obs', [1, 2, 3])
+        ds.to_netcdf(f2)
+
+        aggregate_netcdf_group(self.tempdir, self.tempdir, [f1, f2], 'test')
+        expected = os.path.join(self.tempdir, 'test_19000101T000001-19000101T000006.nc')
+        self.assertTrue(os.path.exists(expected))
+
+        with xr.open_dataset(expected) as ds:
+            self.assertIn('x', ds)
+            self.assertIn('time', ds)
+            self.assertIn('obs', ds.coords)
+            self.assertIn('lat', ds.coords)
+            self.assertIn('lon', ds.coords)
+            self.assertNotIn('depth', ds.coords)
+            self.assertIn('depth', ds)
+
+    def test_aggregate_netcdf_handles_mismatched_coordinates_in_first_dataset(self):
+        f1 = os.path.join(self.tempdir, 'f1.nc')
+        f2 = os.path.join(self.tempdir, 'f2.nc')
+        ds = xr.Dataset()
+        ds['time'] = (['obs'], [1, 2, 4], {})
+        ds['x'] = (['obs'], [1, 2, 3], {})
+        ds.coords['obs'] = ('obs', [1, 2, 3])
+        ds.coords['lat'] = ('obs', [1, 2, 3])
+        ds.coords['lon'] = ('obs', [1, 2, 3])
+        ds.coords['depth'] = ('obs', [1, 2, 3])
+        ds.to_netcdf(f1)
+        ds['time'] = (['obs'], [3, 5, 6], {})
+        del ds.coords['depth']
+        ds.to_netcdf(f2)
+
+        aggregate_netcdf_group(self.tempdir, self.tempdir, [f1, f2], 'test')
+        expected = os.path.join(self.tempdir, 'test_19000101T000001-19000101T000006.nc')
+        self.assertTrue(os.path.exists(expected))
+
+        with xr.open_dataset(expected) as ds:
+            self.assertIn('x', ds)
+            self.assertIn('time', ds)
+            self.assertIn('obs', ds.coords)
+            self.assertIn('lat', ds.coords)
+            self.assertIn('lon', ds.coords)
+            self.assertNotIn('depth', ds.coords)
+            self.assertIn('depth', ds)
+
     def test_aggregate_netcdf_group_missing(self):
         f1 = os.path.join(self.tempdir, 'f1.nc')
         f2 = os.path.join(self.tempdir, 'f2.nc')
@@ -109,7 +164,7 @@ class AggregationTest(unittest.TestCase):
         with xr.open_dataset(expected) as ds:
             self.assertIn('x', ds)
             np.testing.assert_equal(ds.x.values, [[1, 2], [3, 4], [-9999999, -9999999],
-                                                  [5, 6],[-9999999, -9999999], [-9999999, -9999999]])
+                                                  [5, 6], [-9999999, -9999999], [-9999999, -9999999]])
 
     def test_aggregate_netcdf_group_2d_scalar_mixed(self):
         f1 = os.path.join(self.tempdir, 'f1.nc')

--- a/util/xarray_overrides.py
+++ b/util/xarray_overrides.py
@@ -8,10 +8,13 @@ import xarray as xr
 
 from xarray.conventions import (CharToStringArray, NativeEndiannessArray, DecodedCFTimedeltaArray, pop_to,
                                 DecodedCFDatetimeArray, TIME_UNITS, MaskedAndScaledArray, BoolTypeArray)
-from xarray.core.dataset import Dataset
+from xarray.core.dataset import Dataset, as_dataset
+from xarray.core.dataarray import DataArray
 from xarray.core import indexing, utils
 from xarray.core.pycompat import iteritems, OrderedDict
-from xarray.core.variable import as_variable, Variable
+from xarray.core.variable import as_variable, Variable, concat as concat_vars
+from xarray.core.combine import _calc_concat_dim_coord, _calc_concat_over
+from xarray.core.alignment import align
 
 
 # PATCH default XARRAY behavior when restoring string variables from netCDF
@@ -157,6 +160,265 @@ def drop(self, labels, dim=None, inplace=False):
         result = self.loc[{dim: new_index}]
         
     return self if inplace else result
+
+
+def _dataset_concat_coord_patch(datasets, dim, data_vars, coords, compat, positions):
+    """
+    Concatenate a sequence of datasets along a new or existing dimension
+    This version is based on xarray.core.combine._dataset_concat but it will drop mismatched coordinates (remove them
+    from coordinates but keep the variable) instead of throwing a ValueError, it adds logic to fix a bug wherein the 1st
+    dataset is not checked for consistency with the others, and the import statements were removed to the module level.
+    """
+    if compat not in ['equals', 'identical']:
+        raise ValueError("compat=%r invalid: must be 'equals' "
+                         "or 'identical'" % compat)
+
+    dim, coord = _calc_concat_dim_coord(dim)
+    datasets = [as_dataset(ds) for ds in datasets]
+    datasets = align(*datasets, join='outer', copy=False, exclude=[dim])
+
+    concat_over = _calc_concat_over(datasets, dim, data_vars, coords)
+
+    def insert_result_variable(k, v):
+        assert isinstance(v, Variable)
+        if k in datasets[0].coords:
+            result_coord_names.add(k)
+        result_vars[k] = v
+
+    # create the new dataset and add constant variables
+    result_vars = OrderedDict()
+    result_coord_names = set(datasets[0].coords)
+    result_attrs = datasets[0].attrs
+
+    for k, v in datasets[0].variables.items():
+        if k not in concat_over:
+            insert_result_variable(k, v)
+
+    #raise Exception(repr(datasets[0]) + '\n\n' + repr(datasets[1]))
+
+    # check that global attributes and non-concatenated variables are fixed
+    # across all datasets
+    for ds in datasets[1:]:
+        if (compat == 'identical' and
+                not utils.dict_equiv(ds.attrs, result_attrs)):
+            raise ValueError('dataset global attributes not equal')
+        for k, v in iteritems(ds.variables):
+            if k not in result_vars and k not in concat_over:
+                raise ValueError('encountered unexpected variable %r' % k)
+            elif (k in result_coord_names) != (k in ds.coords):
+                # Instead of throwing a ValueError, make the coordinates match by removing the mismatched coordinate
+                if k in result_coord_names:
+                    datasets[0]._coord_names.remove(k)
+                    result_coord_names.remove(k)
+                else:  # k in ds.coords
+                    ds._coord_names.remove(k)
+            elif (k in result_vars and k != dim and
+                  not getattr(v, compat)(result_vars[k])):
+                verb = 'equal' if compat == 'equals' else compat
+                raise ValueError(
+                    'variable %r not %s across datasets' % (k, verb))
+
+    # above for loop fails to check 1st dataset for consistency with the others (i.e. 1st dataset could have a
+    # coordinate not present in the following datasets). The identical attrs check is fine.
+    # Handle this check by comparing the 1st dataset to the 2nd with the 2nd as the control
+
+    if len(datasets) > 1:
+        ds = datasets[0]
+        result_vars.clear()
+        result_coord_names = set(datasets[1].coords)
+
+        for k, v in datasets[1].variables.items():
+            if k not in concat_over:
+                insert_result_variable(k, v)
+
+        for k, v in iteritems(ds.variables):
+            if k not in result_vars and k not in concat_over:
+                raise ValueError('encountered unexpected variable %r' % k)
+            elif (k in result_coord_names) != (k in ds.coords):
+                if k in result_coord_names:
+                    datasets[1]._coord_names.remove(k)
+                    result_coord_names.remove(k)
+                else:  # k in ds.coords
+                    ds._coord_names.remove(k)
+            elif (k in result_vars and k != dim and
+                  not getattr(v, compat)(result_vars[k])):
+                verb = 'equal' if compat == 'equals' else compat
+                raise ValueError(
+                    'variable %r not %s across datasets' % (k, verb))
+
+    # we've already verified everything is consistent; now, calculate
+    # shared dimension sizes so we can expand the necessary variables
+    dim_lengths = [ds.dims.get(dim, 1) for ds in datasets]
+    non_concat_dims = {}
+    for ds in datasets:
+        non_concat_dims.update(ds.dims)
+    non_concat_dims.pop(dim, None)
+
+    def ensure_common_dims(vars):
+        # ensure each variable with the given name shares the same
+        # dimensions and the same shape for all of them except along the
+        # concat dimension
+        common_dims = tuple(pd.unique([d for v in vars for d in v.dims]))
+        if dim not in common_dims:
+            common_dims = (dim,) + common_dims
+        for var, dim_len in zip(vars, dim_lengths):
+            if var.dims != common_dims:
+                common_shape = tuple(non_concat_dims.get(d, dim_len)
+                                     for d in common_dims)
+                var = var.expand_dims(common_dims, common_shape)
+            yield var
+
+    # stack up each variable to fill-out the dataset (in order)
+    for k in datasets[0].variables:
+        if k in concat_over:
+            vars = ensure_common_dims([ds.variables[k] for ds in datasets])
+            combined = concat_vars(vars, dim, positions)
+            insert_result_variable(k, combined)
+
+    result = Dataset(result_vars, attrs=result_attrs)
+    result = result.set_coords(result_coord_names)
+
+    if coord is not None:
+        # add concat dimension last to ensure that its in the final Dataset
+        result[coord.name] = coord
+
+    return result
+
+
+def _dataarray_concat_coord_patch(arrays, dim, data_vars, coords, compat,
+                                  positions):
+    """This version is identical to xarray.core.combine._dataarray_concat except that it calls a patched version of
+    _dataset_concat in order to handle coordinate mismatches."""
+    arrays = list(arrays)
+
+    if data_vars != 'all':
+        raise ValueError('data_vars is not a valid argument when '
+                         'concatenating DataArray objects')
+
+    datasets = []
+    for n, arr in enumerate(arrays):
+        if n == 0:
+            name = arr.name
+        elif name != arr.name:
+            if compat == 'identical':
+                raise ValueError('array names not identical')
+            else:
+                arr = arr.rename(name)
+        datasets.append(arr._to_temp_dataset())
+
+    ds = _dataset_concat_coord_patch(datasets, dim, data_vars, coords, compat,
+                         positions)
+    return arrays[0]._from_temp_dataset(ds, name)
+
+
+def concat_coord_patch(objs, dim=None, data_vars='all', coords='different',
+                       compat='equals', positions=None, indexers=None, mode=None,
+                       concat_over=None):
+    """Concatenate xarray objects along a new or existing dimension.
+    This version is identical to xarray.core.combine.concat except that it calls patched versions of _dataset_concat
+    and _dataarray_concat in order to handle coordinate mismatches and the import statements were removed to the module
+    level.
+
+    Parameters
+    ----------
+    objs : sequence of Dataset and DataArray objects
+        xarray objects to concatenate together. Each object is expected to
+        consist of variables and coordinates with matching shapes except for
+        along the concatenated dimension.
+    dim : str or DataArray or pandas.Index
+        Name of the dimension to concatenate along. This can either be a new
+        dimension name, in which case it is added along axis=0, or an existing
+        dimension name, in which case the location of the dimension is
+        unchanged. If dimension is provided as a DataArray or Index, its name
+        is used as the dimension to concatenate along and the values are added
+        as a coordinate.
+    data_vars : {'minimal', 'different', 'all' or list of str}, optional
+        These data variables will be concatenated together:
+          * 'minimal': Only data variables in which the dimension already
+            appears are included.
+          * 'different': Data variables which are not equal (ignoring
+            attributes) across all datasets are also concatenated (as well as
+            all for which dimension already appears). Beware: this option may
+            load the data payload of data variables into memory if they are not
+            already loaded.
+          * 'all': All data variables will be concatenated.
+          * list of str: The listed data variables will be concatenated, in
+            addition to the 'minimal' data variables.
+        If objects are DataArrays, data_vars must be 'all'.
+    coords : {'minimal', 'different', 'all' o list of str}, optional
+        These coordinate variables will be concatenated together:
+          * 'minimal': Only coordinates in which the dimension already appears
+            are included.
+          * 'different': Coordinates which are not equal (ignoring attributes)
+            across all datasets are also concatenated (as well as all for which
+            dimension already appears). Beware: this option may load the data
+            payload of coordinate variables into memory if they are not already
+            loaded.
+          * 'all': All coordinate variables will be concatenated, except
+            those corresponding to other dimensions.
+          * list of str: The listed coordinate variables will be concatenated,
+            in addition the 'minimal' coordinates.
+    compat : {'equals', 'identical'}, optional
+        String indicating how to compare non-concatenated variables and
+        dataset global attributes for potential conflicts. 'equals' means
+        that all variable values and dimensions must be the same;
+        'identical' means that variable attributes and global attributes
+        must also be equal.
+    positions : None or list of integer arrays, optional
+        List of integer arrays which specifies the integer positions to which
+        to assign each dataset along the concatenated dimension. If not
+        supplied, objects are concatenated in the provided order.
+    indexers, mode, concat_over : deprecated
+
+    Returns
+    -------
+    concatenated : type of objs
+
+    See also
+    --------
+    merge
+    auto_combine
+    """
+    # Below TODOs are copied from the xarray source code
+    # TODO: add join and ignore_index arguments copied from pandas.concat
+    # TODO: support concatenating scalar coordinates even if the concatenated
+    # dimension already exists
+
+    try:
+        first_obj, objs = utils.peek_at(objs)
+    except StopIteration:
+        raise ValueError('must supply at least one object to concatenate')
+
+    if dim is None:
+        warnings.warn('the `dim` argument to `concat` will be required '
+                      'in a future version of xarray; for now, setting it to '
+                      "the old default of 'concat_dim'",
+                      FutureWarning, stacklevel=2)
+        dim = 'concat_dims'
+
+    if indexers is not None:  # pragma: nocover
+        warnings.warn('indexers has been renamed to positions; the alias '
+                      'will be removed in a future version of xarray',
+                      FutureWarning, stacklevel=2)
+        positions = indexers
+
+    if mode is not None:
+        raise ValueError('`mode` is no longer a valid argument to '
+                         'xarray.concat; it has been split into the `data_vars` '
+                         'and `coords` arguments')
+    if concat_over is not None:
+        raise ValueError('`concat_over` is no longer a valid argument to '
+                         'xarray.concat; it has been split into the `data_vars` '
+                         'and `coords` arguments')
+
+    if isinstance(first_obj, DataArray):
+        f = _dataarray_concat_coord_patch
+    elif isinstance(first_obj, Dataset):
+        f = _dataset_concat_coord_patch
+    else:
+        raise TypeError('can only concatenate xarray Dataset and DataArray '
+                        'objects, got %s' % type(first_obj))
+    return f(objs, dim, data_vars, coords, compat, positions)
 
 
 xarray.conventions.decode_cf_variable = decode_cf_variable

--- a/util/xarray_overrides.py
+++ b/util/xarray_overrides.py
@@ -194,8 +194,6 @@ def _dataset_concat_coord_patch(datasets, dim, data_vars, coords, compat, positi
         if k not in concat_over:
             insert_result_variable(k, v)
 
-    #raise Exception(repr(datasets[0]) + '\n\n' + repr(datasets[1]))
-
     # check that global attributes and non-concatenated variables are fixed
     # across all datasets
     for ds in datasets[1:]:
@@ -312,12 +310,10 @@ def _dataarray_concat_coord_patch(arrays, dim, data_vars, coords, compat,
 
 
 def concat_coord_patch(objs, dim=None, data_vars='all', coords='different',
-                       compat='equals', positions=None, indexers=None, mode=None,
-                       concat_over=None):
+                       compat='equals', positions=None):
     """Concatenate xarray objects along a new or existing dimension.
-    This version is identical to xarray.core.combine.concat except that it calls patched versions of _dataset_concat
-    and _dataarray_concat in order to handle coordinate mismatches and the import statements were removed to the module
-    level.
+    This version is based on xarray.core.combine.concat but calls patched versions of _dataset_concat and
+    _dataarray_concat in order to handle coordinate mismatches.
 
     Parameters
     ----------
@@ -368,7 +364,6 @@ def concat_coord_patch(objs, dim=None, data_vars='all', coords='different',
         List of integer arrays which specifies the integer positions to which
         to assign each dataset along the concatenated dimension. If not
         supplied, objects are concatenated in the provided order.
-    indexers, mode, concat_over : deprecated
 
     Returns
     -------
@@ -390,26 +385,7 @@ def concat_coord_patch(objs, dim=None, data_vars='all', coords='different',
         raise ValueError('must supply at least one object to concatenate')
 
     if dim is None:
-        warnings.warn('the `dim` argument to `concat` will be required '
-                      'in a future version of xarray; for now, setting it to '
-                      "the old default of 'concat_dim'",
-                      FutureWarning, stacklevel=2)
-        dim = 'concat_dims'
-
-    if indexers is not None:  # pragma: nocover
-        warnings.warn('indexers has been renamed to positions; the alias '
-                      'will be removed in a future version of xarray',
-                      FutureWarning, stacklevel=2)
-        positions = indexers
-
-    if mode is not None:
-        raise ValueError('`mode` is no longer a valid argument to '
-                         'xarray.concat; it has been split into the `data_vars` '
-                         'and `coords` arguments')
-    if concat_over is not None:
-        raise ValueError('`concat_over` is no longer a valid argument to '
-                         'xarray.concat; it has been split into the `data_vars` '
-                         'and `coords` arguments')
+        raise ValueError("Value of None is not allowed for argument 'dim'.")
 
     if isinstance(first_obj, DataArray):
         f = _dataarray_concat_coord_patch


### PR DESCRIPTION
Added a patched version of _dataset_concat to xarray_overrides so that coordinates not present in all source NetCDF files for an aggregation are dropped (made non-coordinates, not removed entirely) instead of leading to a ValueError. Also corrected a bug in xarray's _dataset_concat where it failed to check the 1st dataset for consistency with the rest of the datasets for concatentation.

NOTE: The mentioned ValueError does not occur unless coordinates are decoded. When they are not decoded, the result is erroneous dropping of unrelated coordinates in the resulting Dataset.