### PR TITLE
Issue #13402 - Make stream resolution independent of delivery method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Stream Engine
 
-# Development Release 1.9.0 2019-04-18
+# Development Release 1.9.0 2019-06-04
+
+Issue #13402 - Make stream resolution independent of delivery method
+- Allow lookup of streams with different method when locating externals
+- Handle non-obs dimensions when processing QC results
 
 Issue #14159 - Record data download size and time data
 - Add endpoint to measure output directory size and write time

--- a/util/qc_executor.py
+++ b/util/qc_executor.py
@@ -97,6 +97,7 @@ class QcExecutor(object):
 
             module = importlib.import_module(ParameterFunction.query.filter_by(function=function_name)
                                              .first().owner)
+
             # call qc function in a separate process to deal with crashes, e.g. segfaults
             read_fd, write_fd = os.pipe()
             processid = os.fork()
@@ -149,9 +150,9 @@ class QcExecutor(object):
             qc_results_name = '_'.join([parameter.name, QC_RESULTS])
 
             if qc_count_name not in dataset:
-                dataset[qc_count_name] = ('obs', np.zeros_like(dataset.time.values, dtype=np.uint8), {})
+                dataset[qc_count_name] = (dataset[parameter.name].dims, np.zeros_like(dataset[parameter.name].values, dtype=np.uint8), {})
             if qc_results_name not in dataset:
-                dataset[qc_results_name] = ('obs', np.zeros_like(dataset.time.values, dtype=np.uint8), {})
+                dataset[qc_results_name] = (dataset[parameter.name].dims, np.zeros_like(dataset[parameter.name].values, dtype=np.uint8), {})
 
             qc_function = ParameterFunction.query.filter_by(function=function_name).first()
             flag = int(qc_function.qc_flag, 2)

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -388,7 +388,10 @@ class StreamDataset(object):
             # remove obs dimension from parameter's dimensions and data (13025 AC2)
             param_dimensions.remove('-obs')
             dims = param_dimensions
-            data = data[0] if data is not None else None
+
+            # remove obs dimension from data - if data is already 1d, assume obs is already absent
+            if data.ndim > 1:
+                data = data[0] if data is not None else None
         elif param_dimensions:
             # append parameter dimensions onto obs
             dims += param_dimensions

--- a/util/stream_request.py
+++ b/util/stream_request.py
@@ -475,43 +475,49 @@ class StreamRequest(object):
         :return:
         """
         log.debug('_find_stream_same_sensor(%r, %r, STREAM_DICTIONARY)', stream_key, streams)
-        method = stream_key.method
         subsite = stream_key.subsite
         node = stream_key.node
         sensor = stream_key.sensor
 
         # Search the same reference designator
         for stream in streams:
-            sensors = stream_dictionary.get(stream, {}).get(method, {}).get(subsite, {}).get(node, [])
-            if sensor in sensors:
-                return StreamKey.from_dict({
-                    "subsite": subsite,
-                    "node": node,
-                    "sensor": sensor,
-                    "method": method,
-                    "stream": stream
-                })
+            # do not restrict the method - try all available
+            potential_methods = stream_dictionary.get(stream, {}).keys()
+            for method in potential_methods:
+                sensors = stream_dictionary.get(stream, {}).get(method, {}).get(subsite, {}).get(node, [])
+                if sensor in sensors:
+                    return StreamKey.from_dict({
+                        "subsite": subsite,
+                        "node": node,
+                        "sensor": sensor,
+                        "method": method,
+                        "stream": stream
+                    })
+
+
 
     @staticmethod
     def _find_stream_from_list(stream_key, streams, sensors, stream_dictionary):
         log.debug('_find_stream_from_list(%r, %r, %r, STREAM_DICTIONARY)', stream_key, streams, sensors)
-        method = stream_key.method
         subsite = stream_key.subsite
         designators = [(c.subsite, c.node, c.sensor) for c in sensors]
 
         for stream in streams:
-            subsite_dict = stream_dictionary.get(stream, {}).get(method, {}).get(subsite, {})
-            for _node in subsite_dict:
-                for _sensor in subsite_dict[_node]:
-                    des = (subsite, _node, _sensor)
-                    if des in designators:
-                        return StreamKey.from_dict({
-                            "subsite": subsite,
-                            "node": _node,
-                            "sensor": _sensor,
-                            "method": method,
-                            "stream": stream
-                        })
+            # do not restrict the method - try all available
+            potential_methods = stream_dictionary.get(stream, {}).keys()
+            for method in potential_methods:
+                subsite_dict = stream_dictionary.get(stream, {}).get(method, {}).get(subsite, {})
+                for _node in subsite_dict:
+                    for _sensor in subsite_dict[_node]:
+                        des = (subsite, _node, _sensor)
+                        if des in designators:
+                            return StreamKey.from_dict({
+                                "subsite": subsite,
+                                "node": _node,
+                                "sensor": _sensor,
+                                "method": method,
+                                "stream": stream
+                            })
 
     @staticmethod
     def _find_stream_same_node(stream_key, streams, stream_dictionary):
@@ -523,20 +529,22 @@ class StreamRequest(object):
         :return: StreamKey if found, otherwise None
         """
         log.debug('_find_stream_same_node(%r, %r, STREAM_DICTIONARY)', stream_key, streams)
-        method = stream_key.method
         subsite = stream_key.subsite
         node = stream_key.node
 
         for stream in streams:
-            sensors = stream_dictionary.get(stream, {}).get(method, {}).get(subsite, {}).get(node, [])
-            if sensors:
-                return StreamKey.from_dict({
-                    "subsite": subsite,
-                    "node": node,
-                    "sensor": sensors[0],
-                    "method": method,
-                    "stream": stream
-                })
+            # do not restrict the method - try all available
+            potential_methods = stream_dictionary.get(stream, {}).keys()
+            for method in potential_methods:
+                sensors = stream_dictionary.get(stream, {}).get(method, {}).get(subsite, {}).get(node, [])
+                if sensors:
+                    return StreamKey.from_dict({
+                        "subsite": subsite,
+                        "node": node,
+                        "sensor": sensors[0],
+                        "method": method,
+                        "stream": stream
+                    })
 
     def interpolate_from_stream_request(self, stream_request):
         source_sk = stream_request.stream_key


### PR DESCRIPTION
qc_executor changes are necessary to handle cases where QC is executed on a parameter dimensioned on something other than obs.