### PR TITLE
Issue #14387 pCO2 sensors not returning recent data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Stream Engine
 
+# Release 1.12.0 2020-02-05
+
+Issue #14387 - pCO2 sensors not returning recent data
+- Select extra data points for supporting streams immediately before and after the
+  request time range for better interpolation. Restrict these extra data points
+  to be from deployments that are within the request time range.
+
 # Release 1.11.0 2019-12-04
 
 Issue #14304 - Add bin size entry for new metbk_ct_dcl_instrument stream

--- a/config/default.py
+++ b/config/default.py
@@ -238,7 +238,7 @@ UI_HARD_LIMIT = 20000
 QC_RESULTS_STORAGE_SYSTEM = 'none'  # 'log' to write qc results to a file, 'cass' to write qc results to a database
 # Number of cassandra rows used to the correct deployment for padding of streams which provide
 # cal coefficients and other needed data
-LOOKBACK_QUERY_LIMIT = 100
+LOOKBACK_QUERY_LIMIT = 1
 MAX_BIN_SIZE_MIN = 20160
 # Where to start unbounded queries 2010-01-01T00:00:00.000Z
 UNBOUND_QUERY_START = 3471292800

--- a/util/cass.py
+++ b/util/cass.py
@@ -116,7 +116,7 @@ def _init():
 
 @log_timing(log)
 def get_cass_lookback_dataset(stream_key, start_time, data_bin, deployment_start_time, request_id):
-    # try to fetch the first n times to ensure we get a deployment value in there.
+    # try to fetch the first n times before the request start time
     cols, rows = fetch_with_func(query_n_before, stream_key,
                                  [(data_bin, start_time, engine.app.config['LOOKBACK_QUERY_LIMIT'])])
     # Only return data gathered after the start of the first deployment
@@ -132,7 +132,7 @@ def get_cass_lookback_dataset(stream_key, start_time, data_bin, deployment_start
 
 @log_timing(log)
 def get_cass_lookforward_dataset(stream_key, end_time, data_bin, deployment_stop_time, request_id):
-    # try to fetch the first n times to ensure we get a deployment value in there.
+    # try to fetch the first n times after the request end time
     cols, rows = fetch_with_func(query_n_after, stream_key,
                                  [(data_bin, end_time, engine.app.config['LOOKBACK_QUERY_LIMIT'])])
     # Only return data gathered before the end of the last deployment

--- a/util/cass.py
+++ b/util/cass.py
@@ -115,17 +115,33 @@ def _init():
 
 
 @log_timing(log)
-def get_cass_lookback_dataset(stream_key, start_time, data_bin, deployments, request_id):
+def get_cass_lookback_dataset(stream_key, start_time, data_bin, deployment_start_time, request_id):
     # try to fetch the first n times to ensure we get a deployment value in there.
     cols, rows = fetch_with_func(query_n_before, stream_key,
                                  [(data_bin, start_time, engine.app.config['LOOKBACK_QUERY_LIMIT'])])
-    needed = set(deployments)
-    dep_idx = cols.index('deployment')
+    # Only return data gathered after the start of the first deployment
+    # within the time range of this request
+    time_idx = cols.index('time')
     ret_rows = []
     for r in rows:
-        if r[dep_idx] in needed:
+        if r[time_idx] >= deployment_start_time:
             ret_rows.append(r)
-            needed.remove(r[dep_idx])
+
+    return to_xray_dataset(cols, ret_rows, stream_key, request_id)
+
+
+@log_timing(log)
+def get_cass_lookforward_dataset(stream_key, end_time, data_bin, deployment_stop_time, request_id):
+    # try to fetch the first n times to ensure we get a deployment value in there.
+    cols, rows = fetch_with_func(query_n_after, stream_key,
+                                 [(data_bin, end_time, engine.app.config['LOOKBACK_QUERY_LIMIT'])])
+    # Only return data gathered before the end of the last deployment
+    # within the time range of this request
+    time_idx = cols.index('time')
+    ret_rows = []
+    for r in rows:
+        if r[time_idx] < deployment_stop_time:
+            ret_rows.append(r)
     return to_xray_dataset(cols, ret_rows, stream_key, request_id)
 
 
@@ -161,6 +177,19 @@ def query_first_after(stream_key, times_and_bins, cols):
 @log_timing(log)
 def query_n_before(stream_key, query_arguments, cols):
     query = "select %s from %s where subsite='%s' and node='%s' and sensor='%s' and bin=? and method='%s' and time <= ? ORDER BY method DESC, time DESC LIMIT ?" % \
+            (', '.join(cols), stream_key.stream.name, stream_key.subsite, stream_key.node,
+             stream_key.sensor, stream_key.method)
+    query = SessionManager.prepare(query)
+    result = []
+    for success, rows in execute_concurrent_with_args(SessionManager.session(), query, query_arguments, concurrency=50):
+        if success:
+            result.extend(list(rows))
+    return result
+
+
+@log_timing(log)
+def query_n_after(stream_key, query_arguments, cols):
+    query = "select %s from %s where subsite='%s' and node='%s' and sensor='%s' and bin=? and method='%s' and time >= ? ORDER BY method ASC, time ASC LIMIT ?" % \
             (', '.join(cols), stream_key.stream.name, stream_key.subsite, stream_key.node,
              stream_key.sensor, stream_key.method)
     query = SessionManager.prepare(query)

--- a/util/metadata_service/partition.py
+++ b/util/metadata_service/partition.py
@@ -140,7 +140,7 @@ def get_first_before_metadata(stream_key, start_time):
     :return:
     """
     res = _query_partition_metadata_before(stream_key, start_time)
-    # filter to ensure start time < time_range_start
+    # filter to ensure first time in bin < time_range_start
     res = filter(lambda x: x.first < start_time, res)
     if not res:
         return {}
@@ -151,10 +151,10 @@ def get_first_before_metadata(stream_key, start_time):
     else:
         # Check same size
         if res[0].count == res[1].count:
-            # take the choosen one
+            # take the chosen one
             res = filter(lambda x: x.store == engine.app.config['PREFERRED_DATA_LOCATION'], res)
             to_use = res[0]
-        # other otherwise take the larger of the two
+        # otherwise take the larger of the two
         else:
             if res[0].count < res[1].count:
                 to_use = res[1]
@@ -173,7 +173,7 @@ def get_first_after_metadata(stream_key, end_time):
     :return:
     """
     res = _query_partition_metadata_after(stream_key, end_time)
-    # filter to ensure end time < time_range_start
+    # filter to ensure last time in bin > time_range_end
     res = filter(lambda x: x.last > end_time, res)
     if not res:
         return {}
@@ -184,10 +184,10 @@ def get_first_after_metadata(stream_key, end_time):
     else:
         # Check same size
         if res[0].count == res[1].count:
-            # take the choosen one
+            # take the chosen one
             res = filter(lambda x: x.store == engine.app.config['PREFERRED_DATA_LOCATION'], res)
             to_use = res[0]
-        # other otherwise take the larger of the two
+        # otherwise take the larger of the two
         else:
             if res[0].count < res[1].count:
                 to_use = res[1]

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -7,14 +7,17 @@ import sys
 import ion_functions
 import numexpr
 import numpy as np
+import time
+import ntplib
 
 from ooi_data.postgres.model import Parameter, Stream
 from util.advlogging import ParameterReport
-from util.cass import fetch_nth_data, get_full_cass_dataset, get_cass_lookback_dataset
+from util.cass import fetch_nth_data, get_full_cass_dataset, get_cass_lookback_dataset, get_cass_lookforward_dataset
 from util.common import (log_timing, ntp_to_datestring, ntp_to_datetime, UnknownFunctionTypeException,
                          StreamEngineException, TimeRange, MissingDataException)
 from util.datamodel import create_empty_dataset, compile_datasets, add_location_data, _get_fill_value
-from util.metadata_service import (SAN_LOCATION_NAME, CASS_LOCATION_NAME, get_first_before_metadata,
+from util.metadata_service import (SAN_LOCATION_NAME, CASS_LOCATION_NAME,
+                                   get_first_before_metadata, get_first_after_metadata,
                                    get_location_metadata)
 
 from util.provenance_metadata_store import ProvenanceMetadataStore
@@ -50,7 +53,7 @@ class StreamDataset(object):
 
     def fetch_raw_data(self, time_range, limit, should_pad):
         dataset = self.get_dataset(time_range, limit, self.provenance_metadata,
-                                   should_pad, [], self.request_id)
+                                   should_pad, self.request_id)
         self._insert_dataset(dataset)
 
     def _insert_dataset(self, dataset):
@@ -699,13 +702,12 @@ class StreamDataset(object):
         return result, version
 
     @log_timing(log)
-    def get_dataset(self, time_range, limit, provenance_metadata, pad_forward, deployments, request_id=None):
+    def get_dataset(self, time_range, limit, provenance_metadata, pad_dataset, request_id=None):
         """
         :param time_range:
         :param limit:
         :param provenance_metadata:
-        :param pad_forward:
-        :param deployments:
+        :param pad_dataset:
         :param request_id:
         :return:
         """
@@ -719,9 +721,21 @@ class StreamDataset(object):
             san_percent = san_locations.total / total
             cass_percent = cass_locations.total / total
 
-        if pad_forward:
-            # pad forward on some datasets
-            datasets.append(self.get_lookback_dataset(self.stream_key, time_range, deployments, request_id))
+        # If this is a supporting stream (ie. not the primary requested stream),
+        # get extra data points on both sides immediately outside of the requested
+        # time range for higher quality interpolation of supporting stream data
+        # into the primary data set at the request time boundaries. The extra
+        # data points must be within the time range of the deployments.
+        if pad_dataset and app.config['LOOKBACK_QUERY_LIMIT'] > 0:
+            # Get the start time of the first and stop time of the last deployments
+            # within the requested time range.
+            deployment_time_range = self.get_deployment_time_range(time_range)
+            if deployment_time_range.get("start", None):
+                datasets.append(self.get_lookback_dataset(self.stream_key, time_range,
+                                                          deployment_time_range["start"], request_id))
+            if deployment_time_range.get("stop", None):
+                datasets.append(self.get_lookforward_dataset(self.stream_key, time_range,
+                                                             deployment_time_range["stop"], request_id))
 
         if san_locations.total > 0:
             # put the range down if we are within the time range
@@ -751,14 +765,71 @@ class StreamDataset(object):
         return compile_datasets(datasets)
 
     @log_timing(log)
-    def get_lookback_dataset(self, key, time_range, deployments, request_id=None):
-        first_metadata = get_first_before_metadata(key, time_range.start)
-        if CASS_LOCATION_NAME in first_metadata:
-            locations = first_metadata[CASS_LOCATION_NAME]
-            return get_cass_lookback_dataset(key, time_range.start, locations.bin_list[0], deployments, request_id)
-        elif SAN_LOCATION_NAME in first_metadata:
-            locations = first_metadata[SAN_LOCATION_NAME]
-            return get_san_lookback_dataset(key, TimeRange(locations.start_time, time_range.start),
-                                            locations.bin_list[0], deployments)
+    def get_lookback_dataset(self, key, request_time_range, deployment_start_time, request_id=None):
+        first_metadata_before = get_first_before_metadata(key, request_time_range.start)
+        if CASS_LOCATION_NAME in first_metadata_before:
+            locations = first_metadata_before[CASS_LOCATION_NAME]
+
+            return get_cass_lookback_dataset(key, request_time_range.start, locations.bin_list[0],
+                                             deployment_start_time, request_id)
+        elif SAN_LOCATION_NAME in first_metadata_before:
+            locations = first_metadata_before[SAN_LOCATION_NAME]
+
+            # Note that the deployments list was originally hardcoded to an empty list ([]) in
+            # StreamDataset.fetch_raw_data(). That same hard code is moved to the function
+            # call below to preserve the behavior of that function while changing the behavior
+            # of the above call to get_cass_lookback_dataset. I would think that the
+            # hard coded empty list of deployment numbers should be removed from the call
+            # below at some point in the future as well. Note that since the list of deployments
+            # is empty, the function call below returns an empty list.
+            return get_san_lookback_dataset(key, TimeRange(locations.start_time, request_time_range.start),
+                                            locations.bin_list[0], [])
         else:
             return None
+
+    @log_timing(log)
+    def get_lookforward_dataset(self, key, request_time_range, deployment_stop_time, request_id=None):
+        first_metadata_after = get_first_after_metadata(key, request_time_range.stop)
+        if CASS_LOCATION_NAME in first_metadata_after:
+            locations = first_metadata_after[CASS_LOCATION_NAME]
+
+            return get_cass_lookforward_dataset(key, request_time_range.stop, locations.bin_list[0],
+                                                deployment_stop_time, request_id)
+        elif SAN_LOCATION_NAME in first_metadata_after:
+            locations = first_metadata_after[SAN_LOCATION_NAME]
+
+            # Note that the deployments list was originally hardcoded to an empty list ([]) in
+            # StreamDataset.fetch_raw_data(). That same hard code when passed to get_san_lookback_dataset()
+            # above results in an empty list getting returned from that function. Instead of implementing an
+            # analogous "do nothing" get_san_lookforward_dataset() function, we just return an empty set
+            # here until that function is properly implemented.
+            return []
+        else:
+            return None
+
+    @log_timing(log)
+    def get_deployment_time_range(self, request_time_range):
+        # The expected deployments are the intersection of those that:
+        # end after the start of the requested time range and
+        # start before the end of the requested time range
+        expected_deployment_numbers = []
+        for dep_no in sorted(self.events.deps):
+            if (request_time_range.start is None or
+                    self.events.deps[dep_no].ntp_stop is None or
+                    self.events.deps[dep_no].ntp_stop >= request_time_range.start) and \
+               (request_time_range.stop is None or
+                    self.events.deps[dep_no].ntp_start is None or
+                    self.events.deps[dep_no].ntp_start < request_time_range.stop):
+                expected_deployment_numbers.append(dep_no)
+
+        # The deployment time range is the start time of the first
+        # deployment and the stop time of the last deployment
+        deployment_time_range = {"start": None, "stop": None}
+        if expected_deployment_numbers:
+            deployment_time_range["start"] = self.events.deps[expected_deployment_numbers[0]].ntp_start
+            deployment_time_range["stop"] = self.events.deps[expected_deployment_numbers[-1]].ntp_stop
+            if deployment_time_range["stop"] is None:
+                deployment_time_range["stop"] = ntplib.system_to_ntp_time(time.time())
+
+        return deployment_time_range
+


### PR DESCRIPTION
In this change, for supporting (interpolated) streams (ie. not the primary requested stream), we will fetch from Cassandra 1 extra data point on both sides immediately outside of the requested time range for higher quality interpolation of supporting stream data into the primary data set at the request time boundaries. The extra data points must be within the time range of the deployments. Note that we only fetch 1 data point on each side since fetching more than this does not have any additional effect as the SciPy interpolate function we are using interpolates from a straight line (linear) drawn between the supporting stream's data points.