### PR TITLE
Issue #14535 - Parameter naming conflict prevents netcdf generation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Stream Engine
 
+# Release 1.13.0 2020-03-04
+
+Issue #14535 - Parameter naming conflict prevents netcdf generation
+
 # Release 1.12.0 2020-02-04
 
 Issue #14573 - Don't interpolate raw data across deployments for the same instrument


### PR DESCRIPTION
If an interpolated parameter has the same name as a parameter in the primary stream, there is a naming conflict error that prevents netcdf generation. The fix will check if a parameter name already exists in a dataset before trying to rename another parameter to that same name. If the name is already being used, the name of the interpolated parameter will not be changed and will appear in the dataset in the format "interpolated_stream_name-parameter_name".