### PR TITLE
Issue #14398 - Cleanup QARTOD NetCDF variables

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 # Stream Engine
 
-# Development Release 1.12.0 2019-11-25
+# Development Release 1.14.0 2020-03-17
+
+Issue #14398 - Cleanup QARTOD NetCDF variables and attributes
 
 Issue #14537 - Updates to use numpy version 1.16; added source field to QARTOD records
 

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -1,6 +1,5 @@
 name: stream
 channels:
-- file://home/1116449/miniconda2/custom_conda_channel
 - defaults
 - ooi
 - conda-forge

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -1,5 +1,6 @@
 name: stream
 channels:
+- file://home/1116449/miniconda2/custom_conda_channel
 - defaults
 - ooi
 - conda-forge
@@ -35,3 +36,4 @@ dependencies:
 - simplejson
 - sqlalchemy=1.1.5
 - xarray=0.9.2
+- werkzeug<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ scipy==1.2.1
 simplejson
 SQLAlchemy==1.1.5
 xarray==0.9.2
+werkzeug<1.0

--- a/util/common.py
+++ b/util/common.py
@@ -31,8 +31,8 @@ ANNOTATION_FILE_FORMAT = '%s_annotations_%s.json'
 QC_EXECUTED = 'qc_executed'
 QC_RESULTS = 'qc_results'
 # QARTOD Parameter identification patterns
-QARTOD_PRIMARY = 'qartod_flag_primary'
-QARTOD_SECONDARY = 'qartod_flag_secondary'
+QARTOD_PRIMARY = 'qartod_results'
+QARTOD_SECONDARY = 'qartod_executed'
 
 
 class QartodFlags:
@@ -54,7 +54,7 @@ class QartodFlags:
 
     @classmethod
     def getQCFlagMeanings(cls):
-        return ["PASS", "NOT_EVALUATED", "SUSPECT", "FAIL", "MISSING"]
+        return ["pass", "not_evaluated", "suspect_or_of_high_interest", "fail", "missing_data"]
 
     @classmethod
     def isValidQCFlag(cls, flag):

--- a/util/netcdf_generator.py
+++ b/util/netcdf_generator.py
@@ -185,7 +185,7 @@ class NetcdfGenerator(object):
                             for need in need_list:
                                 if need.name in params_to_include:
                                     if 'ancillary_variables' in ds[requested_parameter.name].attrs:
-                                        ds[requested_parameter.name].attrs['ancillary_variables'] += "," + need.name
+                                        ds[requested_parameter.name].attrs['ancillary_variables'] += " " + need.name
                                     else:
                                         ds[requested_parameter.name].attrs['ancillary_variables'] = need.name
                                     break


### PR DESCRIPTION
Implement some corrections/enhancements to QARTOD variable names and attributes:
-add QARTOD variables to the 'ancillary_variables' attribute of the parameter they describe
-add a 'references' attribute pointing to QARTOD documentation
-add a 'standard_name' attribute of the form "<parameter standard name> status_flag"
-add a 'comment' attributes with a brief description, and in the case of the "secondary flag", explaining the test result encoding
-update 'flag_meaning' attribute to be lowercase and use more descriptive names (in line with QARTOD manual flag naming)
-update 'long_name' attribute to the form "<parameter long name> <short descriptive phrase>"
-rename QARTOD variables to "qartod_results" and "qartod_executed" (these names are not necessarily final, but at least represent an improvement over "primary" and "secondary")