### PR TITLE
Issue #14675 - Compute depth from pressure

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Stream Engine
 
+# Release 1.17.0
+
+Issue #14675 - Compute depth from pressure
+
 # Release 1.16.0 2020-08-11
 
 Issue #14791 - Correct pressure_depth/int_ctd_pressure handling

--- a/config/default.py
+++ b/config/default.py
@@ -144,6 +144,7 @@ NETCDF_DEPTH_VARIABLES = [
     # The order of the list determines the preferred variable to use in
     # streams containing multiple matching depth variables.
     # #10745 AC 1
+    'depth',
     'sci_water_pressure_dbar',
     'seawater_pressure',
     'pressure_depth',
@@ -313,6 +314,7 @@ UNBOUND_QUERY_START = 3471292800
 # X/Y/Z Interp. Settings   #
 ############################
 PRESSURE_DPI = 'PRESWAT_L1'
+DEPTH_PARAMETER_NAME = 'depth'
 GPS_STREAM_ID = 761
 GPS_LAT_PARAM_ID = 1335
 GPS_LON_PARAM_ID = 1336

--- a/util/datamodel.py
+++ b/util/datamodel.py
@@ -88,21 +88,6 @@ def add_location_data(ds, lat, lon):
     ds['lon'] = ('obs', lon_array, {'axis': 'X', 'units': 'degrees_east', 'standard_name': 'longitude'})
 
 
-def find_depth_variable(variable_list):
-    """
-    Find the depth variable in the variable_list
-    :param variable_list: the list of variable names
-    :return: the depth variable, or None if the variable_list contains no known depth variable
-    """
-    depth_variable = None
-    # iterate through the config variables to ensure variables are found in order of preference
-    for variable in app.config.get('NETCDF_DEPTH_VARIABLES', []):
-        if variable in variable_list:
-            depth_variable = variable
-            break
-    return depth_variable
-
-
 def to_xray_dataset(cols, data, stream_key, request_uuid, san=False, keep_exclusions=False):
     """
     Make an xray dataset from the raw cassandra data

--- a/util/stream_request.py
+++ b/util/stream_request.py
@@ -11,7 +11,7 @@ from ooi_data.postgres.model import Parameter, Stream, NominalDepth
 from util.asset_management import AssetManagement
 from util.cass import fetch_l0_provenance
 from util.common import log_timing, StreamEngineException, StreamKey, MissingDataException, read_size_config, \
-    find_depth_variable, isfillvalue, QC_SUFFIXES
+    isfillvalue, QC_SUFFIXES
 from util.metadata_service import build_stream_dictionary, get_available_time_range
 from util.qc_executor import QcExecutor
 from util.qartod_qc_executor import QartodQcExecutor
@@ -36,6 +36,7 @@ SECONDS_PER_BYTE = app.config.get('SECONDS_PER_BYTE', 0.0000041)  # default byte
 MINIMUM_REPORTED_TIME = app.config.get('MINIMUM_REPORTED_TIME')
 DEPTH_FILL = app.config['DEPTH_FILL']
 PRESSURE_DEPTH_APPLICABLE_STREAM_KEYS = app.config['PRESSURE_DEPTH_APPLICABLE_STREAM_KEYS']
+DEPTH_PARAMETER_NAME = app.config.get('DEPTH_PARAMETER_NAME')
 
 
 class StreamRequest(object):
@@ -163,6 +164,16 @@ class StreamRequest(object):
                 if not self.datasets[stream_key].datasets:
                     del self.datasets[stream_key]
 
+        # Remove pressure_depth if it is not applicable to prevent misguided uses of rubbish
+        # pressure_depth data when pressure should be interpolated from the CTD stream
+        for stream_key in list(self.datasets):
+            if not self._is_pressure_depth_valid(stream_key) and self.datasets[stream_key].datasets:
+                for _, ds in self.datasets[stream_key].datasets.iteritems():
+                    pressure_depth = Parameter.query.get(PRESSURE_DEPTH_PARAM_ID)
+                    if pressure_depth.name in ds:
+                        del ds[pressure_depth.name]
+                
+
     def calculate_derived_products(self):
         # Calculate all internal-only data products
         for sk in self.datasets:
@@ -283,11 +294,7 @@ class StreamRequest(object):
                     for target_sk in self.datasets:
                         self.datasets[target_sk].interpolate_into(source_sk, self.datasets[source_sk], param)
 
-        # for instruments with usable pressure_depth, we do not add int_ctd_pressure
-        if self._is_pressure_depth_valid(self.stream_key):
-            return
-
-        # determine if there is a pressure parameter available (9328)
+        # determine if there is a pressure parameter available (9328) - should be none when _is_pressure_depth_valid evaluates to True
         pressure_params = [(sk, param) for sk in self.external_includes for param in self.external_includes[sk]
                            if param.data_product_identifier == PRESSURE_DPI]
 
@@ -307,17 +314,28 @@ class StreamRequest(object):
         for deployment in self.datasets[self.stream_key].datasets:
             ds = self.datasets[self.stream_key].datasets[deployment]
 
-            # if we got to this point, we are not using pressure_depth
-            pressure_depth = Parameter.query.get(PRESSURE_DEPTH_PARAM_ID)
-            if pressure_depth.name in ds:
-                del ds[pressure_depth.name]
-
             # If we used the CTD pressure, then rename it to the configured final name (e.g. 'int_ctd_pressure')
             if pressure_name in ds.data_vars:
                 pressure_value = ds.data_vars[pressure_name]
                 del ds[pressure_name]
                 pressure_value.name = INT_PRESSURE_NAME
                 self.datasets[self.stream_key].datasets[deployment][INT_PRESSURE_NAME] = pressure_value
+
+        # determine if there is a depth parameter available
+        # depth is computed from pressure, so look for it in the same stream
+        depth_key, depth_param = self.find_stream(self.stream_key, tuple(Parameter.query.filter(Parameter.name == DEPTH_PARAMETER_NAME)), pressure_key.stream)
+
+        if not depth_param:
+            return
+
+        if depth_key not in self.datasets:
+            return
+
+        # update external_includes for any post processing that looks at it - pressure was already handled, but depth was not
+        self.external_includes.setdefault(depth_key, set()).add(depth_param)
+
+        # interpolate depth computed from CTD pressure
+        self.datasets[self.stream_key].interpolate_into(depth_key, self.datasets.get(depth_key), depth_param)
 
     def rename_parameters(self):
         """
@@ -416,10 +434,11 @@ class StreamRequest(object):
         """
         external_to_process = set()
         if self.stream_key.is_mobile and not self._is_pressure_depth_valid(self.stream_key):
-            dpi = PRESSURE_DPI
+            # add pressure parameter
             external_to_process.add((None, tuple(Parameter.query.filter(
-                Parameter.data_product_identifier == dpi).all())))
-
+                Parameter.data_product_identifier == PRESSURE_DPI).all())))
+            # do NOT add depth parameter here; we want to make sure it comes from the
+            # same stream as the pressure parameter (which has not been determined yet)
         if self.stream_key.is_glider:
             gps_stream = Stream.query.get(GPS_STREAM_ID)
             external_to_process.add((gps_stream, (Parameter.query.get(GPS_LAT_PARAM_ID),)))
@@ -439,6 +458,16 @@ class StreamRequest(object):
             internal_requested = [p for p in self.stream_key.stream.parameters if p.id in self.requested_parameters]
         else:
             internal_requested = self.stream_key.stream.parameters
+
+        pressure_depth = Parameter.query.get(PRESSURE_DEPTH_PARAM_ID)
+        if pressure_depth in internal_requested and not self._is_pressure_depth_valid(self.stream_key):
+            log.debug('<%s> removing invalid pressure_depth from requested parameters', self.request_id)
+            internal_requested.remove(pressure_depth)
+            log.debug('<%s> removing invalid depth computed from invalid pressure_depth from requested parameters', self.request_id)
+            for param in internal_requested:
+                if param.name == DEPTH_PARAMETER_NAME:
+                    internal_requested.remove(param)
+
         self.requested_parameters = internal_requested
 
         # Identify internal parameters needed to support this query


### PR DESCRIPTION
Streams using a collocated CTD for pressure (which gets added by existing logic in stream_engine) need to have stream_engine add the depth parameter from that same CTD stream. Other streams, e.g. CTD streams themselves, have depth added to them via preload-database updates.