### PR TITLE
FEAT: load_qartod.py -  read Postgres credentials from .env file

### DIFF
--- a/scripts/load_qartod.py
+++ b/scripts/load_qartod.py
@@ -135,10 +135,10 @@ def parse_climatology_table(filepath, param_dict):
     return '%s%s%s' % (prefix, ', '.join(configs), suffix)
 
 
-def insert_qartod_records(qartod_list):
-    host = raw_input('Connecting to PostgreSQL to insert QARTOD records...\nhost: ')
-    username = raw_input('Connecting to PostgreSQL to insert QARTOD records...\nusername: ')
-    password = getpass.getpass('password: ')
+def insert_qartod_records(qartod_list, hostname = None, username = None, password = None):
+    host = hostname or raw_input('Connecting to PostgreSQL to insert QARTOD records...\nhost: ')
+    username = username or raw_input('Connecting to PostgreSQL to insert QARTOD records...\nusername: ')
+    password = password or getpass.getpass('password: ')
     connection = None
     try:
         connection = psycopg2.connect(user=username, password=password, host=host, port='5432', database='metadata')
@@ -164,7 +164,23 @@ def main():
     parser.add_argument("file", type=str, help="filepath for the QARTOD test CSV file to parse")
     args = parser.parse_args()
     data = parse_qartod_file(args.file)
-    insert_qartod_records(data)
+    # Try to pick up database credentials from environment
+    import os
+
+    try:
+        hostname = os.environ['POSTGRES_HOSTNAME']
+    except KeyError:
+        hostname = None
+    try:
+        username = os.environ['POSTGRES_USERNAME']
+    except KeyError:
+        username = None
+    try:
+        password = os.environ['POSTGRES_PASSWORD']
+    except KeyError:
+        password = None
+    
+    insert_qartod_records(data, hostname=hostname, username=username, password=password)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updating `scripts/load_qartod.py` to try to load Postgres credentials from environment variables.

The variables are:
* `POSTGRES_HOSTNAME`
* `POSTGRES_USERNAME`
* `POSTGRES_PASSWORD`

Use this with the new `qartod/load_all_csvs_into_postgres.sh` file added to the [qc-lookup](https://github.com/oceanobservatories/qc-lookup) repo to load qartod tests for all available CSVs by providing the above variables in a `.env` file alongside that script. This is to help avoid requiring a human in the loop to run `load_qartod.py` in a scripted environment.