### PR TITLE
Feature/parameterized deduplication

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Stream Engine
 
+# Release 1.20.18 2025-09-30
+
+Issue #16068 - Adds new parameters to IFCB streams
+
 # Release 1.20.17 2025-08-06
 
 Issue #15668 - Enhancements to process that copies data in Cassandra and changes deployment number

--- a/config/default.py
+++ b/config/default.py
@@ -227,7 +227,7 @@ FILL_VALUES = {
 
 STREAM_DEDUPLICATION_MAP = {
     # Streams for which duplicates should be pruned based on more than time
-    'plims_a_hdr_instrument': {'time': None, 'sample_adc_file_row_number': int},
+    'plims_a_adc_instrument': {'time': None, 'sample_adc_file_row_number': int},
 }
 
 

--- a/config/default.py
+++ b/config/default.py
@@ -1,6 +1,7 @@
 import os
-from util.releasenotes import ReleaseNotes
 from collections import OrderedDict
+
+from util.releasenotes import ReleaseNotes
 
 ############################
 # General Settings         #
@@ -223,6 +224,12 @@ FILL_VALUES = {
     "string": "",
     "boolean": -9
 }
+
+STREAM_DEDUPLICATION_MAP = {
+    # Streams for which duplicates should be pruned based on more than time
+    'plims_a_hdr_instrument': {'time': None, 'sample_adc_file_row_number': int},
+}
+
 
 # Used for fill values when location data is missing
 LAT_FILL = 90.0

--- a/config/default.py
+++ b/config/default.py
@@ -225,9 +225,14 @@ FILL_VALUES = {
     "boolean": -9
 }
 
+# Streams for which duplicates should be pruned based on more than time
+# Note that order matters; use OrderedDict to ensure it is preserved
+
+plims_a_adc_dict = OrderedDict()
+plims_a_adc_dict['time'] = None
+plims_a_adc_dict['sample_adc_file_row_number'] = int
 STREAM_DEDUPLICATION_MAP = {
-    # Streams for which duplicates should be pruned based on more than time
-    'plims_a_adc_instrument': {'time': None, 'sample_adc_file_row_number': int},
+    'plims_a_adc_instrument': plims_a_adc_dict,
 }
 
 

--- a/util/datamodel.py
+++ b/util/datamodel.py
@@ -306,9 +306,9 @@ def compile_datasets(datasets, filter_variable_type_map=None):
         dataset = dataset.reindex({'obs': sorted_idx})
     else:
         # sort the dataset by the configured variables
-        vars = filter_variable_type_map.keys()
+        filter_vars = filter_variable_type_map.keys()
         df = pd.DataFrame({var: dataset[var].values.astype(var_type) if var_type else dataset[var].values for var, var_type in filter_variable_type_map.items()})
-        sorted_df = df.sort_values(by=vars, ascending=np.ones(len(vars), dtype='bool'))
+        sorted_df = df.sort_values(by=filter_vars, ascending=np.ones(len(filter_vars), dtype='bool'))
         ind = sorted_df.index
         dataset = dataset.reindex({'obs': ind})
 

--- a/util/datamodel.py
+++ b/util/datamodel.py
@@ -9,10 +9,9 @@ import msgpack
 import numpy as np
 import pandas as pd
 import xarray as xr
-
 from common import StreamEngineException
-from multi_concat import multi_concat
 from engine import app
+from multi_concat import multi_concat
 
 __author__ = 'Stephen Zakrewsky'
 
@@ -273,7 +272,7 @@ def _fix_data_arrays(data, unpacked):
                 _fix_data_arrays(data_sub, unpacked_sub)
 
 
-def compile_datasets(datasets):
+def compile_datasets(datasets, filter_variable_type_map=None):
     """
     Given a list of datasets. Possibly containing None. Return a single
     dataset with unique indexes and sorted by the 'time' parameter
@@ -300,9 +299,19 @@ def compile_datasets(datasets):
 
     # recreate the obs dimension
     dataset['obs'] = np.arange(dataset.obs.size)
-    # sort the dataset by time
-    sorted_idx = dataset.time.argsort()
-    dataset = dataset.reindex({'obs': sorted_idx})
+
+    if filter_variable_type_map is None:
+        # sort the dataset by time
+        sorted_idx = dataset.time.argsort()
+        dataset = dataset.reindex({'obs': sorted_idx})
+    else:
+        # sort the dataset by the configured variables
+        vars = filter_variable_type_map.keys()
+        df = pd.DataFrame({var: dataset[var].values.astype(var_type) if var_type else dataset[var].values for var, var_type in filter_variable_type_map.items()})
+        sorted_df = df.sort_values(by=vars, ascending=np.ones(len(vars), dtype='bool'))
+        ind = sorted_df.index
+        dataset = dataset.reindex({'obs': ind})
+
     # recreate the obs dimension again to ensure it is sequential
     dataset['obs'] = np.arange(dataset.obs.size)
     return dataset

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -133,13 +133,12 @@ class StreamDataset(object):
             sorted_df = df.sort_values(by=vars, ascending=np.ones(len(vars), dtype='bool'))
 
             for var in vars:
-                mask = mask | np.diff(sorted_df[var], prepend=0.0) != 0
+                var_mask = np.diff(sorted_df[var], prepend=0.0) != 0
+                mask = mask | var_mask
             
         if not mask.all():
             # Get indices of masked values in the original dataset
             ind = sorted_df.index[mask]
-            # Sort indices to maintain original order
-            ind = np.sort(ind)
             # Subselect the dataset
             dataset = dataset.isel(obs=ind)
             # Reindex the obs dimension

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -96,9 +96,9 @@ class StreamDataset(object):
                     dataset.deployment.values[mask] = deployment_number
 
             for deployment, group in dataset.groupby('deployment'):
-                if self.stream_key in STREAM_DEDUPLICATION_MAP:
+                if self.stream_key.stream.name in STREAM_DEDUPLICATION_MAP:
                     # If the stream key is in the deduplication map, prune duplicates
-                    self.datasets[deployment] = self._prune_duplicates(group, STREAM_DEDUPLICATION_MAP[self.stream_key])
+                    self.datasets[deployment] = self._prune_duplicates(group, STREAM_DEDUPLICATION_MAP[self.stream_key.stream.name])
                 else:
                     self.datasets[deployment] = self._prune_duplicate_times(group)
                 self.params[deployment] = [p for p in self.stream_key.stream.derived]
@@ -131,9 +131,8 @@ class StreamDataset(object):
                 values = dataset[var].values
                 if var_type:
                     values = values.astype(var_type)
-                var_mask = np.diff(dataset[var].values) != 0
-                # unique, indices = np.unique(values, return_index=True)
-                mask = mask & var_mask
+                var_mask = np.diff(values, prepend=0.0) != 0
+                mask = mask | var_mask
             
         if not mask.all():
             dataset = dataset.isel(obs=mask)

--- a/util/stream_dataset.py
+++ b/util/stream_dataset.py
@@ -1,36 +1,56 @@
+import datetime
 import importlib
+import inspect
 import json
 import logging
-import datetime
 import sys
-import inspect
+import time
 
 import ion_functions
+import ntplib
 import numexpr
 import numpy as np
-import time
-import ntplib
-
+from engine import app
 from ooi_data.postgres.model import Parameter, Stream
 from util.advlogging import ParameterReport
-from util.cass import fetch_nth_data, get_full_cass_dataset, get_cass_lookback_dataset, get_cass_lookforward_dataset
-from util.common import (log_timing, ntp_to_datestring, ntp_to_datetime, UnknownFunctionTypeException,
-                         StreamEngineException, TimeRange, MissingDataException)
-from util.datamodel import create_empty_dataset, compile_datasets, add_location_data, _get_fill_value
-from util.metadata_service import (SAN_LOCATION_NAME, CASS_LOCATION_NAME,
-                                   get_first_before_metadata, get_first_after_metadata,
-                                   get_location_metadata)
-
+from util.cass import (
+    fetch_nth_data,
+    get_cass_lookback_dataset,
+    get_cass_lookforward_dataset,
+    get_full_cass_dataset,
+)
+from util.common import (
+    MissingDataException,
+    StreamEngineException,
+    TimeRange,
+    UnknownFunctionTypeException,
+    log_timing,
+    ntp_to_datestring,
+    ntp_to_datetime,
+)
+from util.datamodel import (
+    _get_fill_value,
+    add_location_data,
+    compile_datasets,
+    create_empty_dataset,
+)
+from util.metadata_service import (
+    CASS_LOCATION_NAME,
+    SAN_LOCATION_NAME,
+    get_first_after_metadata,
+    get_first_before_metadata,
+    get_location_metadata,
+)
 from util.provenance_metadata_store import ProvenanceMetadataStore
-from util.san import fetch_nsan_data, fetch_full_san_data, get_san_lookback_dataset
+from util.san import fetch_full_san_data, fetch_nsan_data, get_san_lookback_dataset
 from util.xray_interpolation import interp1d_data_array
-from engine import app
 
 log = logging.getLogger(__name__)
 
 PYTHON_VERSION = '.'.join(map(str, (sys.version_info[0:3])))
 ION_VERSION = getattr(ion_functions, '__version__', 'unversioned')
 INSTRUMENT_ATTRIBUTE_MAP = app.config.get('INSTRUMENT_ATTRIBUTE_MAP')
+STREAM_DEDUPLICATION_MAP = app.config.get('STREAM_DEDUPLICATION_MAP', None)
 
 
 class StreamDataset(object):
@@ -76,7 +96,11 @@ class StreamDataset(object):
                     dataset.deployment.values[mask] = deployment_number
 
             for deployment, group in dataset.groupby('deployment'):
-                self.datasets[deployment] = self._prune_duplicate_times(group)
+                if self.stream_key in STREAM_DEDUPLICATION_MAP:
+                    # If the stream key is in the deduplication map, prune duplicates
+                    self.datasets[deployment] = self._prune_duplicates(group, STREAM_DEDUPLICATION_MAP[self.stream_key])
+                else:
+                    self.datasets[deployment] = self._prune_duplicate_times(group)
                 self.params[deployment] = [p for p in self.stream_key.stream.derived]
 
         else:
@@ -89,6 +113,32 @@ class StreamDataset(object):
             dataset = dataset.isel(obs=mask)
             dataset['obs'] = np.arange(dataset.obs.size)
         return dataset
+
+    def _prune_duplicates(self, dataset, filter_variable_type_map = {}):
+        """
+        Prune duplicate values from the dataset based on the specified variables.
+        :param dataset: The dataset to prune
+        :param filter_variable_type_map: A dictionary with variables to check for duplicates as keys with their types as values
+        :return: The pruned dataset
+        """ 
+        mask = np.ones(dataset.obs.size, dtype='bool')
+        if not filter_variable_type_map:
+            mask = np.diff(dataset.time.values, prepend=0.0) != 0
+            
+        for var, var_type in filter_variable_type_map.items():
+            if var in dataset:
+                # need to handle data type as well
+                values = dataset[var].values
+                if var_type:
+                    values = values.astype(var_type)
+                var_mask = np.diff(dataset[var].values) != 0
+                # unique, indices = np.unique(values, return_index=True)
+                mask = mask & var_mask
+            
+        if not mask.all():
+            dataset = dataset.isel(obs=mask)
+            dataset['obs'] = np.arange(dataset.obs.size)
+        return dataset  
 
     def calculate_all(self, source_datasets=None, ignore_missing_optional_params=False):
         """


### PR DESCRIPTION
Adding parameterized sorting and deduplication. The initial change is for IFCB/plims specifically, but was designed to be configurable  so other streams with time-duplicated data can have custom sorting and deduplication mechanisms aside from time-only sorting and deduplication.

The sorting is ordered by the OrderedDict of parameters to sort by, using Pandas `DataFrame.sort_values`, which allows ranked sorting by columns. This occurs both at deduplication time, then again at aggregation.

The deduplication happens only at deduplication time (right after raw data are pulled from Cassandra), and the filters are applied as masks, combined with bitwise OR. Sorting happens as part of the deduplication process, then again during aggregation to ensure final NetCDF files returned are properly sorted according to the custom sort ordering rules. CSV files will be sorted due to sorting in deduplication (since they are not aggregated presently).