### PR TITLE
Changing location of deduplication map setting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Stream Engine
 
-# Release 1.20.18 2025-09-30
+# Release 1.20.19 2025-09-30
 
 Issue #16068 - Adds new parameters to IFCB streams
 

--- a/config/default.py
+++ b/config/default.py
@@ -225,17 +225,6 @@ FILL_VALUES = {
     "boolean": -9
 }
 
-# Streams for which duplicates should be pruned based on more than time
-# Note that order matters; use OrderedDict to ensure it is preserved
-
-plims_a_adc_dict = OrderedDict()
-plims_a_adc_dict['time'] = None
-plims_a_adc_dict['sample_adc_file_row_number'] = int
-STREAM_DEDUPLICATION_MAP = {
-    'plims_a_adc_instrument': plims_a_adc_dict,
-}
-
-
 # Used for fill values when location data is missing
 LAT_FILL = 90.0
 LON_FILL = -180.0


### PR DESCRIPTION
Removed IFCB deduplciation map setting from default.py. Site-specific configs belong in configs/local.py.